### PR TITLE
Stop the member maps walk on model graph cycles

### DIFF
--- a/src/MongODM.Core/Serialization/Mapping/MapRegistry.cs
+++ b/src/MongODM.Core/Serialization/Mapping/MapRegistry.cs
@@ -565,8 +565,8 @@ namespace Etherna.MongODM.Core.Serialization.Mapping
          * on the member or mapped for the type, never enters the document serialization
          * pipeline, and opts out for value-object-like models.
          * The exploration runs on the schema class maps, before member maps
-         * initialization: building the member maps of an entity model embedding itself
-         * would recurse without end. */
+         * initialization: an invalid configuration fails with its detailed violations
+         * before any member map is built and registered. */
         private void ValidateEntityModelMembers()
         {
             List<string> violations = [];

--- a/src/MongODM.Core/Serialization/Mapping/ModelMap.cs
+++ b/src/MongODM.Core/Serialization/Mapping/ModelMap.cs
@@ -112,9 +112,10 @@ namespace Etherna.MongODM.Core.Serialization.Mapping
         {
             foreach (var schema in SchemasById.Values)
             {
+                HashSet<IModelMapSchema> visitedSchemas = [schema];
                 foreach (var bsonMemberMap in schema.AllMemberMaps)
                 {
-                    var memberMap = BuildMemberMap(bsonMemberMap, schema, null);
+                    var memberMap = BuildMemberMap(bsonMemberMap, schema, null, visitedSchemas);
                     _definedMemberMaps.Add(memberMap);
                     ((ModelMapSchema)schema).AddGeneratedMemberMap(memberMap);
                 }
@@ -163,10 +164,16 @@ namespace Etherna.MongODM.Core.Serialization.Mapping
         }
 
         // Helpers.
+        /* The visited schemas set carries the model map schemas open on the current
+         * recursion path, root schema included. A model graph cycle (e.g. a self nesting
+         * value object, or a reference summary schema denormalizing a reference to its own
+         * model) reaches a schema already on the path: descending into it again would
+         * recurse without end, so the walk skips it, building each member map path once. */
         private static MemberMap BuildMemberMap(
             BsonMemberMap bsonMemberMap,
             IModelMapSchema modelMapSchema,
-            IMemberMap? parentMemberMap)
+            IMemberMap? parentMemberMap,
+            HashSet<IModelMapSchema> visitedSchemas)
         {
             var memberMap = new MemberMap(bsonMemberMap, modelMapSchema, parentMemberMap);
 
@@ -191,15 +198,21 @@ namespace Etherna.MongODM.Core.Serialization.Mapping
                     {
                         foreach (var schema in modelMap.SchemasById.Values)
                         {
+                            //skip schemas already on the recursion path, closing a model graph cycle
+                            if (!visitedSchemas.Add(schema))
+                                continue;
+
                             schema.Freeze();
 
                             // Recursion on child member maps.
                             foreach (var childBsonMemberMap in schema.AllMemberMaps)
                             {
-                                var childMemberMap = BuildMemberMap(childBsonMemberMap, schema, memberMap);
+                                var childMemberMap = BuildMemberMap(childBsonMemberMap, schema, memberMap, visitedSchemas);
                                 memberMap.AddChildMemberMap(childMemberMap);
                                 ((ModelMapSchema)schema).AddGeneratedMemberMap(childMemberMap);
                             }
+
+                            visitedSchemas.Remove(schema);
                         }
                     }
                 }

--- a/test/MongODM.Core.UnitTests/MapRegistryTest.cs
+++ b/test/MongODM.Core.UnitTests/MapRegistryTest.cs
@@ -128,6 +128,17 @@ namespace Etherna.MongODM.Core
         {
             public string? Name { get; set; }
         }
+        public class TreeNodeModel
+        {
+            public IEnumerable<TreeNodeModel>? Children { get; set; }
+            public string? Name { get; set; }
+            public TreeNodeModel? Parent { get; set; }
+        }
+        public class TwinChildHostModel
+        {
+            public FirstModel? FirstChild { get; set; }
+            public FirstModel? SecondChild { get; set; }
+        }
         public class UntypedIdModel : IEntityModel<object>
         {
             public IDictionary<string, object>? ExtraElements { get; }
@@ -263,6 +274,41 @@ namespace Etherna.MongODM.Core
                 new KeyModel("keyVal"));
             bsonWriter.WriteEndDocument();
             Assert.Equal("keyVal", serializedDocument["key"].AsString);
+        }
+
+        [Fact]
+        public void FreezeBuildsChildMemberMapsForRepeatedEmbeddedModelMembers()
+        {
+            /* MODM-224: the member maps walk skips only the schemas already open on its own
+             * recursion path: a schema reached again on a sibling branch builds its child
+             * member maps once per branch. */
+
+            // Setup.
+            dbContextEngineMock.Setup(e => e.MapRegistry)
+                .Returns(mapRegistry);
+
+            mapRegistry.AddModelMap<FirstModel>("firstSchemaId");
+            mapRegistry.AddModelMap<TwinChildHostModel>("twinHostSchemaId", cm =>
+            {
+                cm.SetMemberSerializer(m => m.FirstChild!, new MappedSerializerAdapter<FirstModel>(dbContextEngineMock.Object));
+                cm.SetMemberSerializer(m => m.SecondChild!, new MappedSerializerAdapter<FirstModel>(dbContextEngineMock.Object));
+            });
+
+            // Action.
+            mapRegistry.Freeze();
+
+            // Assert.
+            string[] expectedMemberMapIds =
+            [
+                $"{nameof(TwinChildHostModel)};twinHostSchemaId;{nameof(TwinChildHostModel.FirstChild)}",
+                $"{nameof(TwinChildHostModel)};twinHostSchemaId;{nameof(TwinChildHostModel.FirstChild)}|{nameof(FirstModel)};firstSchemaId;{nameof(FirstModel.Name)}",
+                $"{nameof(TwinChildHostModel)};twinHostSchemaId;{nameof(TwinChildHostModel.SecondChild)}",
+                $"{nameof(TwinChildHostModel)};twinHostSchemaId;{nameof(TwinChildHostModel.SecondChild)}|{nameof(FirstModel)};firstSchemaId;{nameof(FirstModel.Name)}"
+            ];
+            var hostModelMap = mapRegistry.GetModelMap(typeof(TwinChildHostModel));
+            Assert.Equal(
+                expectedMemberMapIds,
+                hostModelMap.AllDescendingMemberMaps.Select(mm => mm.Id).Order(StringComparer.Ordinal));
         }
 
         [Fact]
@@ -628,6 +674,47 @@ namespace Etherna.MongODM.Core
         }
 
         [Fact]
+        public void FreezeSucceedsWithCyclicReferenceSummarySchemas()
+        {
+            /* MODM-224: a reference summary schema can reach itself through the reference
+             * members it denormalizes: the member maps walk stops when a schema repeats on
+             * its recursion path, instead of overflowing the stack at engine build. */
+
+            // Setup.
+            dbContextEngineMock.Setup(e => e.MapRegistry)
+                .Returns(mapRegistry);
+
+            BsonClassMap<ChildModel> childSummaryClassMap = null!;
+            var childRefSerializer = new ReferenceSerializer<ChildModel, string>(
+                dbContextEngineMock.Object,
+                config => config.AddModelMap<ChildModel>("childRefSchemaId", cm =>
+                {
+                    childSummaryClassMap = cm;
+                    cm.MapMember(c => c.Name);
+                }));
+            //close the cycle: the summary schema references its model through the same serializer
+            childSummaryClassMap.MapMember(c => c.Parent).SetSerializer(childRefSerializer);
+
+            mapRegistry.AddModelMap<EntityChildHostModel>("hostSchemaId", cm =>
+                cm.SetMemberSerializer(m => m.Child!, childRefSerializer));
+
+            // Action.
+            mapRegistry.Freeze();
+
+            // Assert.
+            string[] expectedMemberMapIds =
+            [
+                $"{nameof(EntityChildHostModel)};hostSchemaId;{nameof(EntityChildHostModel.Child)}",
+                $"{nameof(EntityChildHostModel)};hostSchemaId;{nameof(EntityChildHostModel.Child)}|{nameof(ChildModel)};childRefSchemaId;{nameof(ChildModel.Name)}",
+                $"{nameof(EntityChildHostModel)};hostSchemaId;{nameof(EntityChildHostModel.Child)}|{nameof(ChildModel)};childRefSchemaId;{nameof(ChildModel.Parent)}"
+            ];
+            var hostModelMap = mapRegistry.GetModelMap(typeof(EntityChildHostModel));
+            Assert.Equal(
+                expectedMemberMapIds,
+                hostModelMap.AllDescendingMemberMaps.Select(mm => mm.Id).Order(StringComparer.Ordinal));
+        }
+
+        [Fact]
         public void FreezeSucceedsWithEmbeddedPlainModelMember()
         {
             /* Only entity models can't embed: models without identity keep serializing
@@ -707,6 +794,42 @@ namespace Etherna.MongODM.Core
 
             // Assert.
             Assert.True(mapRegistry.IsFrozen);
+        }
+
+        [Fact]
+        public void FreezeSucceedsWithSelfNestingModelMembers()
+        {
+            /* MODM-224: a mapped type reachable from itself through its member serializers
+             * is a legal non entity configuration: the member maps walk stops when a schema
+             * repeats on its recursion path, building each member map path once instead of
+             * overflowing the stack at engine build. */
+
+            // Setup.
+            dbContextEngineMock.Setup(e => e.MapRegistry)
+                .Returns(mapRegistry);
+
+            mapRegistry.AddModelMap<TreeNodeModel>("treeNodeSchemaId", cm =>
+            {
+                cm.MapMember(m => m.Name);
+                cm.SetMemberSerializer(m => m.Children!, new EnumerableSerializer<TreeNodeModel>(
+                    new MappedSerializerAdapter<TreeNodeModel>(dbContextEngineMock.Object)));
+                cm.SetMemberSerializer(m => m.Parent!, new MappedSerializerAdapter<TreeNodeModel>(dbContextEngineMock.Object));
+            });
+
+            // Action.
+            mapRegistry.Freeze();
+
+            // Assert.
+            string[] expectedMemberMapIds =
+            [
+                $"{nameof(TreeNodeModel)};treeNodeSchemaId;{nameof(TreeNodeModel.Children)}",
+                $"{nameof(TreeNodeModel)};treeNodeSchemaId;{nameof(TreeNodeModel.Name)}",
+                $"{nameof(TreeNodeModel)};treeNodeSchemaId;{nameof(TreeNodeModel.Parent)}"
+            ];
+            var treeNodeModelMap = mapRegistry.GetModelMap(typeof(TreeNodeModel));
+            Assert.Equal(
+                expectedMemberMapIds,
+                treeNodeModelMap.AllDescendingMemberMaps.Select(mm => mm.Id).Order(StringComparer.Ordinal));
         }
 
         [Fact]


### PR DESCRIPTION
## Issue

[MODM-224](https://etherna.atlassian.net/browse/MODM-224) — building the member maps at engine build is a recursive descent through the member serializers. A cycle in the model graph makes it descend forever, so the **process dies of stack overflow at startup**, on configurations that are perfectly legal:

- a value object nesting itself (a tree node with `Parent` and `Children`);
- a reference summary schema denormalizing a reference to its own model — the open question of the issue: it overflowed too.

## What changes

`ModelMap.BuildMemberMap` carries the model map schemas **open on the current recursion path** (the root one included, seeded by `InitializeMemberMaps`). Before descending into a schema it adds it, and skips when it's already there — a schema repeating on the path is a cycle. After the descent it removes it.

That removal is the point: with a **global** visited set instead of a path-scoped one, a type embedded by two different members would silently lose the child member maps of the second one.

A cyclic member map is built with **no child member maps** — each path is built once, as the issue proposed — rather than granting one more nesting level.

`MapRegistry.ValidateEntityModelMembers` kept a comment justifying its ordering with the endless recursion this fix removes. The ordering still holds for another reason, now stated: an invalid configuration fails with its detailed violations before any member map is built and registered.

## Tests

`FreezeSucceedsWithSelfNestingModelMembers` and `FreezeSucceedsWithCyclicReferenceSummarySchemas` assert the exact set of generated member map ids, so they pin the shape of the walk and not only its termination. `FreezeBuildsChildMemberMapsForRepeatedEmbeddedModelMembers` pins the sibling branches case.

Build Release green with 0 warnings on every target framework; full suite **455 passed**. The tests discriminate: without the guard the test host crashes with a stack overflow on both cycle tests, and without the backtracking removal the sibling branches test goes red.

[MODM-224]: https://etherna.atlassian.net/browse/MODM-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ