### PR TITLE
Audit the transitive dependencies, reporting advisories as warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,14 @@
 <Project>
   <PropertyGroup>
-    <!-- Audit only direct dependencies, not transitive ones -->
-    <NuGetAuditMode>direct</NuGetAuditMode>
+    <!-- Audit direct and transitive dependencies: the packages of this graph prone to receive
+         advisories (the official driver stack pulled by Hangfire.Mongo, the Microsoft.Extensions
+         floor of Hangfire.NetCore) are all transitive. Explicit, to not depend on the SDK default.
+         The audit codes stay warnings under the projects TreatWarningsAsErrors: an advisory is
+         published on a schedule nobody controls, and breaking every build over it would also block
+         the update fixing it. They are reported by the restore of any build, and by the vulnerable
+         packages report of `dotnet list package`. -->
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
 
     <!-- GitVersion.MsBuild writes and reads its version file at a per project path shared by every
          build instance of a multi targeting project: parallel target framework inner builds race on

--- a/samples/AspNetCoreSample/AspNetCoreSample.csproj
+++ b/samples/AspNetCoreSample/AspNetCoreSample.csproj
@@ -9,10 +9,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <NoWarn>NU1903</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\MongODM.Core.Generators\MongODM.Core.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\src\MongODM.AspNetCore.UI\MongODM.AspNetCore.UI.csproj" />


### PR DESCRIPTION
## Issue

[MODM-226](https://etherna.atlassian.net/browse/MODM-226) — `Directory.Build.props` opted out of auditing transitive dependencies:

```xml
<!-- Audit only direct dependencies, not transitive ones -->
<NuGetAuditMode>direct</NuGetAuditMode>
```

That is the opposite of where this graph carries risk: the packages prone to receive advisories — the official driver stack pulled by `Hangfire.Mongo`, the `Microsoft.Extensions` floor of `Hangfire.NetCore` — are all transitive, so a known vulnerability on any of them surfaced nowhere.

## What changes

`NuGetAuditMode` is `all`, kept explicit so it doesn't depend on the SDK default, and the audit codes are **warnings** rather than build breakers: `WarningsNotAsErrors` lists the NU19xx family (low to critical) against the projects' `TreatWarningsAsErrors`. An advisory is published on a schedule nobody controls, and failing every build over a dependency nobody touched would also block the update fixing it. The advisory is reported by the restore of any build, and by the vulnerable packages report of `dotnet list package`.

The sample dropped its `NoWarn NU1903` for Debug builds: dead while the audit was `direct`, it would have masked exactly the high severity advisories the audit now surfaces.

No `dependabot.yml`: the repository already has Dependabot alerts and automated security fixes enabled, which is what opens PRs for vulnerable dependencies. A version updates configuration would only add weekly upgrade PRs, not security coverage.

## Verification

Forced restore under `all` clean, Release build with 0 warnings on every target framework, full suite **457 passed**, sample built in Debug (the configuration whose `NoWarn` was removed) with 0 warnings. The graph is clean today: `dotnet list package` reports no vulnerable package across the 11 projects.

The configuration itself is proved on a scratch project pulling `Newtonsoft.Json 10.0.1` transitively:

- with `NuGetAuditMode=direct` (the previous setting): restored silently, nothing reported;
- with this branch's `Directory.Build.props` verbatim: `warning NU1903: Package 'Newtonsoft.Json' 10.0.1 has a known high severity vulnerability, GHSA-5crp-9r3c-p9vr`, and `Build succeeded`.

[MODM-226]: https://etherna.atlassian.net/browse/MODM-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ