### PR TITLE
Serve the developer exception page only in development

### DIFF
--- a/samples/AspNetCoreSample/Program.cs
+++ b/samples/AspNetCoreSample/Program.cs
@@ -21,6 +21,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using System;
 
 namespace Etherna.MongODM.AspNetCoreSample
@@ -66,10 +67,15 @@ namespace Etherna.MongODM.AspNetCoreSample
 
             var app = builder.Build();
 
-            // Configure the HTTP request pipeline.
-            app.UseHttpsRedirection();
+            /* Configure the HTTP request pipeline. Exception messages can quote document
+             * content, so the developer exception page is served only in development,
+             * while any other environment gets the generic error page. */
+            if (app.Environment.IsDevelopment())
+                app.UseDeveloperExceptionPage();
+            else
+                app.UseExceptionHandler("/Error");
 
-            app.UseDeveloperExceptionPage();
+            app.UseHttpsRedirection();
 
             app.UseStaticFiles();
 


### PR DESCRIPTION
## Issue

[MODM-241](https://etherna.atlassian.net/browse/MODM-241) — the sample called `UseDeveloperExceptionPage()` unconditionally, so a pipeline copied from it returns exception messages and stack traces to clients in **every** environment. MongODM messages quote document content: `DiscriminatorRegistry` throws `Unknown discriminator value '{discriminator}'`, embedding the document's own `_t`.

## What changes

The developer page is served in Development only; any other environment gets `UseExceptionHandler("/Error")`, the page the sample already ships. The branch sits at the **top** of the pipeline, ahead of `UseHttpsRedirection` where the developer page used to be, so the handler wraps everything downstream — the ASP.NET Core template order.

`using Microsoft.Extensions.Hosting;` is required: the already imported `Microsoft.AspNetCore.Hosting` only exposes the obsolete `IsDevelopment` overload.

## Verification

No test project references the sample, so the check is running it. The real app ran against a dedicated mongod, with a temporary page throwing an exception of the shape that leaks:

```
Production, with this change   ->  GET /Boom = 500, the sample "Error." page
                                   0 occurrences of the message, 0 of the exception type
Production, with dev's code    ->  GET /Boom = 500, the developer page
                                   the message and the exception type in clear
```

`GET /` and `GET /MongODM` keep answering 200 in Production. Build Release green with 0 warnings on every target framework; full suite **490 passed**.

Worth knowing for anyone repeating it: `dotnet run` applies `launchSettings.json`, which forces `ASPNETCORE_ENVIRONMENT=Development` — the run needs `--no-launch-profile` to be a Production one.

## Note

`UseHsts()`, which the framework template puts in the same non-development branch, is deliberately left out: it is a transport concern, not an information disclosure one.

[MODM-241]: https://etherna.atlassian.net/browse/MODM-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ