### PR TITLE
Register the member maps at every nesting depth

### DIFF
--- a/src/MongODM.Core/Serialization/Mapping/MemberMap.cs
+++ b/src/MongODM.Core/Serialization/Mapping/MemberMap.cs
@@ -43,7 +43,7 @@ namespace Etherna.MongODM.Core.Serialization.Mapping
 
         // Properties.
         public IEnumerable<IMemberMap> AllDescendingMemberMaps =>
-            ChildMemberMaps.Concat(ChildMemberMaps.SelectMany(mm => mm.ChildMemberMaps));
+            ChildMemberMaps.Concat(ChildMemberMaps.SelectMany(mm => mm.AllDescendingMemberMaps));
 
         public BsonMemberMap BsonMemberMap { get; }
 

--- a/test/MongODM.Core.UnitTests/MapRegistryTest.cs
+++ b/test/MongODM.Core.UnitTests/MapRegistryTest.cs
@@ -81,6 +81,12 @@ namespace Etherna.MongODM.Core
             public string? Area { get; set; }
             public int Number { get; set; }
         }
+        /* The deep host nests a reference under three embedding levels: the reference member
+         * maps are the fourth level from the root. */
+        public class DeepChildHostModel
+        {
+            public OuterLayerModel? Outer { get; set; }
+        }
         public class DictionaryChildHostModel : IEntityModel<string>
         {
             public IDictionary<string, object>? ExtraElements { get; }
@@ -111,6 +117,10 @@ namespace Etherna.MongODM.Core
             public string? Name { get; set; }
         }
         public interface IKeyModel;
+        public class InnerLayerModel
+        {
+            public ChildModel? Child { get; set; }
+        }
         public class InterfaceIdModel : IEntityModel<IKeyModel>
         {
             public IDictionary<string, object>? ExtraElements { get; }
@@ -135,6 +145,10 @@ namespace Etherna.MongODM.Core
 
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, KeyModel value) =>
                 context.Writer.WriteString(value.Value);
+        }
+        public class OuterLayerModel
+        {
+            public InnerLayerModel? Inner { get; set; }
         }
         public class PlainChildHostModel
         {
@@ -779,6 +793,62 @@ namespace Etherna.MongODM.Core
             // Assert.
             Assert.DoesNotContain(typeof(object), mapRegistry.MapsByModelType.Keys);
             Assert.IsType<ObjectSerializer>(serializerRegistry.GetSerializer<object>());
+        }
+
+        [Fact]
+        public void FreezeRegistersMemberMapsAtEveryNestingDepth()
+        {
+            /* MODM-248: the member maps walk descends to every depth, so a reference
+             * denormalized under three embedding levels enters the registers the
+             * dependencies propagation resolves against: the member map of a summarized
+             * member by id and by member info, and the id member map by element path. */
+
+            // Setup.
+            dbContextEngineMock.Setup(e => e.MapRegistry)
+                .Returns(mapRegistry);
+
+            mapRegistry.AddModelMap<InnerLayerModel>("innerLayerSchemaId", cm =>
+            {
+                cm.AutoMap();
+                cm.SetMemberSerializer(m => m.Child!, new ReferenceSerializer<ChildModel, string>(
+                    dbContextEngineMock.Object,
+                    config =>
+                    {
+                        config.AddModelMap<FakeEntityModelBase<string>>("childBaseSchemaId", cm2 => cm2.MapIdMember(c => c.Id));
+                        config.AddModelMap<ChildModel>("childSchemaId", cm2 => cm2.MapMember(c => c.Name));
+                    }));
+            });
+            mapRegistry.AddModelMap<OuterLayerModel>("outerLayerSchemaId", cm =>
+            {
+                cm.AutoMap();
+                cm.SetMemberSerializer(m => m.Inner!, new MappedSerializerAdapter<InnerLayerModel>(dbContextEngineMock.Object));
+            });
+            mapRegistry.AddModelMap<DeepChildHostModel>("deepHostSchemaId", cm =>
+            {
+                cm.AutoMap();
+                cm.SetMemberSerializer(m => m.Outer!, new MappedSerializerAdapter<OuterLayerModel>(dbContextEngineMock.Object));
+            });
+
+            // Action.
+            mapRegistry.Freeze();
+
+            // Assert.
+            var deepChildNameMemberMapId =
+                $"{nameof(DeepChildHostModel)};deepHostSchemaId;{nameof(DeepChildHostModel.Outer)}|" +
+                $"{nameof(OuterLayerModel)};outerLayerSchemaId;{nameof(OuterLayerModel.Inner)}|" +
+                $"{nameof(InnerLayerModel)};innerLayerSchemaId;{nameof(InnerLayerModel.Child)}|" +
+                $"{nameof(ChildModel)};childSchemaId;{nameof(ChildModel.Name)}";
+            var deepChildNameMemberMap = Assert.Contains(deepChildNameMemberMapId, mapRegistry.MemberMapsById);
+
+            Assert.Contains(
+                deepChildNameMemberMap,
+                mapRegistry.GetMemberMapsFromMemberInfo(typeof(ChildModel).GetProperty(nameof(ChildModel.Name))!));
+
+            var deepChildIdMemberMap = deepChildNameMemberMap.OwnerEntityIdMap;
+            Assert.NotNull(deepChildIdMemberMap);
+            Assert.Contains(
+                deepChildIdMemberMap,
+                mapRegistry.GetMemberMapsWithSameElementPath(deepChildIdMemberMap));
         }
 
         [Fact]

--- a/test/MongODM.IntegrationTests/ModelMaps/MessageMap.cs
+++ b/test/MongODM.IntegrationTests/ModelMaps/MessageMap.cs
@@ -24,6 +24,8 @@ namespace Etherna.MongODM.IntegrationTests.ModelMaps
     {
         public void Register(IDbContextEngine dbContextEngine)
         {
+            dbContextEngine.MapRegistry.AddModelMap<Dispatch>("c9dc5a5d-54ed-475c-8262-7a748e233226");
+
             dbContextEngine.MapRegistry.AddModelMap<Envelope>(
                 "86d458e2-e618-466f-b29c-bf04fceb5196",
                 mm =>

--- a/test/MongODM.IntegrationTests/Models/Dispatch.cs
+++ b/test/MongODM.IntegrationTests/Models/Dispatch.cs
@@ -12,42 +12,25 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
-using Etherna.MongODM.Core.Domain.Models;
-using System.Collections.Generic;
-
 namespace Etherna.MongODM.IntegrationTests.Models
 {
-    public class Message : EntityModelBase<string>
+    /// <summary>
+    /// A value object embedded by <see cref="Message"/>, wrapping an <see cref="Envelope"/>
+    /// into one more document level: the account references it hosts are the fourth
+    /// member map level from the message root.
+    /// </summary>
+    public class Dispatch
     {
-        // Fields.
-        private List<AccountBase> _watchers = [];
-
         // Constructors.
-        public Message(string text, AccountBase author, AccountBase editor)
+        public Dispatch(Envelope envelope)
         {
-            Text = text;
-            Author = author;
-            Editor = editor;
+            Envelope = envelope;
         }
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        protected Message() { }
+        protected Dispatch() { }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         // Properties.
-        public virtual AccountBase Author { get; protected set; }
-        public virtual IEnumerable<Envelope> Batches { get; set; } = [];
-        public virtual Dispatch? Dispatch { get; set; }
-        public virtual AccountBase Editor { get; set; }
-        public virtual Envelope? Envelope { get; set; }
-        public virtual string Text { get; set; }
-        public virtual IEnumerable<AccountBase> Watchers
-        {
-            get => _watchers;
-            protected set => _watchers = [.. value ?? []];
-        }
-
-        // Methods.
-        public virtual void AddWatcher(AccountBase watcher) =>
-            _watchers.Add(watcher);
+        public virtual Envelope Envelope { get; protected set; }
     }
 }

--- a/test/MongODM.IntegrationTests/UpdateDocDependenciesTests.cs
+++ b/test/MongODM.IntegrationTests/UpdateDocDependenciesTests.cs
@@ -786,6 +786,42 @@ namespace Etherna.MongODM.IntegrationTests
             Assert.Equal("Web3Account", rawSecondBatchAlice["_t"].AsString);
         }
 
+        [Fact]
+        public async Task UpdatesSummariesHostedUnderThreeEmbeddingLevels()
+        {
+            /* MODM-248: a reference denormalized under three embedding levels (the
+             * dispatch, its envelope, the recipients collection) has its member maps at
+             * the fourth level from the document root: they register like the shallower
+             * ones, so the change of the referenced account refreshes the deep summary. */
+
+            // Setup.
+            using var contextHandler = AsyncLocalContext.Instance.InitAsyncLocalContext();
+            fixture.TaskRunner.ClearPending();
+
+            var alice = new Web2Account("alice");
+            await dbContext.Accounts.CreateAsync(alice);
+
+            var message = new Message("hello", alice, alice)
+            {
+                Dispatch = new Dispatch(new Envelope([alice]))
+            };
+            await dbContext.Messages.CreateAsync(message);
+
+            // Action: evolve alice into a web3 account, and execute the enqueued task.
+            var web3Alice = new Web3Account(alice, "0x0123456789");
+            await dbContext.Accounts.ReplaceAsync(web3Alice);
+            await fixture.TaskRunner.ExecutePendingAsync(fixture.ServiceProvider);
+
+            // Assert.
+            var messagesCollection = dbContext.Engine.Database.GetCollection<BsonDocument>("messages");
+            var rawMessage = await messagesCollection.Find(IdFilter(message.Id)).SingleAsync();
+
+            var rawAlice = rawMessage["Dispatch"]["Envelope"]["Recipients"].AsBsonArray.Single().AsBsonDocument;
+            Assert.Equal("Web3Account", rawAlice["_t"].AsString);
+            Assert.Equal("06d4e4c1-1e57-4bd0-a071-90fe7d3dbc2a", rawAlice["_s"].AsString); //summary schema of the new type
+            Assert.Equal("alice", rawAlice["Username"].AsString);
+        }
+
         // Helpers.
         private async Task<(long FindAndModify, long Update)> GetServerCommandCountersAsync()
         {


### PR DESCRIPTION
Fixes [MODM-248](https://etherna.atlassian.net/browse/MODM-248).

## Problem

`MemberMap.AllDescendingMemberMaps` promised every descending member map but stopped at the grandchildren: the second term of the concatenation read `mm.ChildMemberMaps` instead of recursing. Counting from a root model map member, the walk covered levels 1 to 3 and dropped everything from the fourth level down.

The engine build fills the member map registers (`MemberMapsById`, the member info index and the root model map plus element path index) from exactly that property, and those registers are what the dependencies propagation resolves against (`DbMaintainer.OnUpdatedModelAsync`, `UpdateDocDependenciesTask`, the delete propagation). A reference denormalized under three embedding levels was invisible to all of them: when the referenced model changed, its deep summary was never refreshed, with no exception nor log.

## Change

- `MemberMap.AllDescendingMemberMaps` recurses: `ChildMemberMaps.Concat(ChildMemberMaps.SelectMany(mm => mm.AllDescendingMemberMaps))`. The member maps walk terminates on model graph cycles (the schemas open on the recursion path are skipped at build), so the recursion is bounded.

## Tests

- `MapRegistryTest.FreezeRegistersMemberMapsAtEveryNestingDepth`: a reference nested under three embedding levels (`DeepChildHostModel.Outer` → `OuterLayerModel.Inner` → `InnerLayerModel.Child`) has its summary member maps at the fourth level, and the test pins they enter the three registers the propagation uses: by id, by member info (`GetMemberMapsFromMemberInfo`), and the owner id member map by element path (`GetMemberMapsWithSameElementPath`).
- `UpdateDocDependenciesTests.UpdatesSummariesHostedUnderThreeEmbeddingLevels`: a new `Dispatch` value object wrapping an `Envelope`, embedded by `Message`, hosts account summaries at `Dispatch.Envelope.Recipients[]`; the type change of the referenced account refreshes the deep summary (`_t`, `_s`, `Username`).
- Both tests fail on the previous implementation (`MemberMapsById` misses the deep member map; the deep summary stays `Web2Account`).

Full solution builds in Release with 0 warnings on every target framework; all unit and integration tests pass.

## Scope

The wiki already describes the propagation as reaching every referencing document of the application, without depth limits: no documentation change needed.

[MODM-248]: https://etherna.atlassian.net/browse/MODM-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ