### PR TITLE
Remove superfluous tests from the test suites

### DIFF
--- a/test/MongODM.Core.UnitTests/Utility/DbSessionHandlerTest.cs
+++ b/test/MongODM.Core.UnitTests/Utility/DbSessionHandlerTest.cs
@@ -15,7 +15,6 @@
 using Etherna.MongoDB.Driver;
 using Etherna.MongODM.Core.ExecContext.AsyncLocal;
 using Moq;
-using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -129,14 +128,6 @@ namespace Etherna.MongODM.Core.Utility
         {
             Assert.Null(AsyncLocalContext.Instance.Items);
             Assert.Null(DbSessionHandler.TryGetCurrentSession(engineMock.Object));
-        }
-
-        [Fact]
-        public void NullArgumentsAreRejected()
-        {
-            Assert.Throws<ArgumentNullException>(() => new DbSessionHandler(null!, sessionMock.Object));
-            Assert.Throws<ArgumentNullException>(() => new DbSessionHandler(engineMock.Object, null!));
-            Assert.Throws<ArgumentNullException>(() => DbSessionHandler.TryGetCurrentSession(null!));
         }
     }
 }

--- a/test/MongODM.IntegrationTests/CustomIdTypeTests.cs
+++ b/test/MongODM.IntegrationTests/CustomIdTypeTests.cs
@@ -215,41 +215,6 @@ namespace Etherna.MongODM.IntegrationTests
         }
 
         [Fact]
-        public async Task CustomSerializedIdPersistsWithItsCustomRepresentation()
-        {
-            // Setup.
-            using var contextHandler = AsyncLocalContext.Instance.InitAsyncLocalContext();
-            var artifact = new Artifact(new Fingerprint("f0e1d2"), "binaries");
-            await dbContext.Artifacts.CreateAsync(artifact);
-
-            // Action.
-            var artifactsCollection = dbContext.Engine.Database.GetCollection<BsonDocument>("artifacts");
-            var rawArtifact = await (await artifactsCollection.FindAsync(
-                Builders<BsonDocument>.Filter.Eq("_id", "f0e1d2"))).SingleAsync();
-
-            // Assert.
-            Assert.Equal(BsonType.String, rawArtifact["_id"].BsonType);
-            Assert.Equal("binaries", rawArtifact["Label"].AsString);
-        }
-
-        [Fact]
-        public async Task CustomSerializedMemberPersistsWithItsCustomRepresentation()
-        {
-            // Setup.
-            using var contextHandler = AsyncLocalContext.Instance.InitAsyncLocalContext();
-            var seal = new Seal(new Fingerprint("09f8e7"));
-            await dbContext.Seals.CreateAsync(seal);
-
-            // Action.
-            var sealsCollection = dbContext.Engine.Database.GetCollection<BsonDocument>("seals");
-            var rawSeal = await (await sealsCollection.FindAsync(
-                Builders<BsonDocument>.Filter.Eq("_id", ObjectId.Parse(seal.Id)))).SingleAsync();
-
-            // Assert.
-            Assert.Equal("09f8e7", rawSeal[nameof(Seal.ArtifactFingerprint)].AsString);
-        }
-
-        [Fact]
         public async Task OperatorShapedIdValueDoesntMatchAnyDocument()
         {
             /* MODM-222: an id value serialized to a document whose first element name


### PR DESCRIPTION
Closes [MODM-257](https://etherna.atlassian.net/browse/MODM-257).

## What the issue asked

A full sweep of the four test suites (520 test methods across 69 test files), run with the criterion
established at the MODM-255 review — every test must pin behavior that could actually regress while
the suite stays green — listed the superfluous tests to drop. Removing them loses no regression
signal, only redundant code to maintain.

## What is removed

**Two strict duplicates in `test/MongODM.IntegrationTests/CustomIdTypeTests.cs`**, both subsumed by
`SerializeIdsWithTheirExpectedDocumentRepresentation`, which asserts the whole raw documents against
their shell json:

- `CustomSerializedIdPersistsWithItsCustomRepresentation` created an `Artifact` through the same
  `Artifacts.CreateAsync` path and asserted only that the raw `_id` is a plain string plus the
  `Label` value; the shell json assertion pins both facts, and finds the document by its string id.
  The round trip half is separately pinned by `CreateAndFindEntityByCustomSerializedId`.
- `CustomSerializedMemberPersistsWithItsCustomRepresentation` asserted only that the raw
  `ArtifactFingerprint` element is the plain string; the same shell json assertion pins that element
  on a `Seal` created the same way. The query side is separately pinned by
  `QueryEntityByCustomSerializedMember`.

**The guard clause test `DbSessionHandlerTest.NullArgumentsAreRejected`**, the case the issue left to
decide at implementation: it pinned only the presence of three `ArgumentNullException.ThrowIfNull`
guards of an internal ambient state handler, passing `null!` to defeat the nullable annotations. The
guards are house-wide convention boilerplate, no caller passes null, and this was the only guard
clause test across the four suites — the suites otherwise treat guard clauses as not-pinned
behavior, so keeping this one was arbitrary. Its `using System;` goes with it.

## Scope

Nothing else came out of the sweep: `MongODM.Core.Generators.UnitTests` and
`MongODM.AspNetCore.UI.UnitTests` are clean, and the reviewed borderline cases — thin facade
forwards, allow-path guard tests, integration tests shadowing unit tests end to end — all pin
behavior their siblings don't.

## Verification

Full solution build in Release, 0 warnings on net8.0, net9.0 and net10.0. Full test suite green:
350 core unit tests, 5 generator, 86 dashboard, 189 integration against a real MongoDB.

[MODM-257]: https://etherna.atlassian.net/browse/MODM-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ