### PR TITLE
Replace the foreign license headers of the index migration log models

### DIFF
--- a/src/MongODM.Core/Domain/Models/DbMigrationOpAgg/BuildNewIndexesMigrationLog.cs
+++ b/src/MongODM.Core/Domain/Models/DbMigrationOpAgg/BuildNewIndexesMigrationLog.cs
@@ -1,15 +1,15 @@
-// Copyright 2021-present Etherna SA
-// This file is part of Etherna Gateway.
+// Copyright 2020-present Etherna SA
+// This file is part of MongODM.
 // 
-// Etherna Gateway is free software: you can redistribute it and/or modify it under the terms of the
-// GNU Affero General Public License as published by the Free Software Foundation,
+// MongODM is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
 // either version 3 of the License, or (at your option) any later version.
 // 
-// Etherna Gateway is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-// See the GNU Affero General Public License for more details.
+// See the GNU Lesser General Public License for more details.
 // 
-// You should have received a copy of the GNU Affero General Public License along with Etherna Gateway.
+// You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
 namespace Etherna.MongODM.Core.Domain.Models.DbMigrationOpAgg

--- a/src/MongODM.Core/Domain/Models/DbMigrationOpAgg/DeleteOldIndexesMigrationLog.cs
+++ b/src/MongODM.Core/Domain/Models/DbMigrationOpAgg/DeleteOldIndexesMigrationLog.cs
@@ -1,15 +1,15 @@
-// Copyright 2021-present Etherna SA
-// This file is part of Etherna Gateway.
+// Copyright 2020-present Etherna SA
+// This file is part of MongODM.
 // 
-// Etherna Gateway is free software: you can redistribute it and/or modify it under the terms of the
-// GNU Affero General Public License as published by the Free Software Foundation,
+// MongODM is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
 // either version 3 of the License, or (at your option) any later version.
 // 
-// Etherna Gateway is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-// See the GNU Affero General Public License for more details.
+// See the GNU Lesser General Public License for more details.
 // 
-// You should have received a copy of the GNU Affero General Public License along with Etherna Gateway.
+// You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
 namespace Etherna.MongODM.Core.Domain.Models.DbMigrationOpAgg


### PR DESCRIPTION
Closes [MODM-258](https://etherna.atlassian.net/browse/MODM-258).

## What the issue asked

`src/MongODM.Core/Domain/Models/DbMigrationOpAgg/BuildNewIndexesMigrationLog.cs` and
`DeleteOldIndexesMigrationLog.cs` carried the full Etherna Gateway header — "This file is part of
Etherna Gateway", licensed under the GNU **Affero** General Public License — instead of the standard
MongODM LGPL header. They were the only two files in `src/` with a foreign header, against the 205
carrying the standard one.

This also protects the premise of MODM-252, which declares LGPL-3.0-or-later on the repo and on the
packages stating that the source headers declare LGPL: these two files were the exception that
statement didn't account for.

## The change

Both headers replaced with the standard MongODM one, verbatim from a sibling file of the same folder
(`MigrationLogBase.cs`), copyright line included: `2020-present`, the year every other source file
carries — it dates the project, not the file, and stays one uniform string across the repo. Nothing
else in the two files is touched.

## Verification

No occurrence of "Etherna Gateway" or "Affero" is left in `src/`, `test/`, `samples/` or the root
markdown files.

Full solution build in Release, 0 warnings on net8.0, net9.0 and net10.0. Full test suite green:
351 core unit tests, 5 generator, 86 dashboard, 191 integration against a real MongoDB.

[MODM-258]: https://etherna.atlassian.net/browse/MODM-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ