### PR TITLE
Materialize the writable properties cache entries

### DIFF
--- a/src/MongODM.Core/ReflectionHelper.cs
+++ b/src/MongODM.Core/ReflectionHelper.cs
@@ -144,9 +144,11 @@ namespace Etherna.MongODM.Core
                         stackType = stackType.BaseType;
                     } while (stackType != null);
                     
+                    //materialize, so the registry entry is a snapshot instead of a query re-run at every enumeration
                     value = typeStack
                         .SelectMany(type => type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
-                        .Where(prop => prop.CanWrite);
+                        .Where(prop => prop.CanWrite)
+                        .ToArray();
                     propertyRegistry.Add(objectType, value);
                 }
                 return value;


### PR DESCRIPTION
Closes [MODM-259](https://etherna.atlassian.net/browse/MODM-259).

## What the issue asked

`ReflectionHelper.GetWritableInstanceProperties` stored into `propertyRegistry` the lazy LINQ query
itself, so the cache held an un-materialized `IEnumerable<PropertyInfo>`: every enumeration of a
"cached" entry re-ran the whole reflection walk (`GetProperties` over the full type stack), outside
the registry lock. The cache never cached — it only kept the captured type stack alive.

The consumer is `Repository.RefreshModel`, which enumerates it to copy the persisted document state
back into the saved model: once per model refreshed by a member level save, a hot path of every unit
of work flush.

## The change

`ToArray()` before adding the value to the registry, so the entries become immutable snapshots
computed once per type. No behavior change: reflection is pure, so the set and the order of the
returned properties are identical.

## Tests

None. The fix has no observable effect on what the method returns — re-running the query always
yields the same properties — so no assertion on the returned values can tell the two versions apart,
and a test asserting the runtime type of the cached collection would pin a shape rather than a
behavior. The existing suites cover the consumer path.

## Verification

Full solution build in Release, 0 warnings on net8.0, net9.0 and net10.0. Full test suite green:
351 core unit tests, 5 generator, 86 dashboard, 191 integration against a real MongoDB.

[MODM-259]: https://etherna.atlassian.net/browse/MODM-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ