### PR TITLE
Claim the maps registration items list through the locking extensions

### DIFF
--- a/src/MongODM.Core/Utility/MapsRegistrationHandler.cs
+++ b/src/MongODM.Core/Utility/MapsRegistrationHandler.cs
@@ -13,7 +13,7 @@
 // If not, see <https://www.gnu.org/licenses/>.
 
 using Etherna.MongODM.Core.ExecContext;
-using Etherna.MongODM.Core.ExecContext.Exceptions;
+using Etherna.MongODM.Core.Extensions;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -38,13 +38,8 @@ namespace Etherna.MongODM.Core.Utility
         public MapsRegistrationHandler(IExecutionContext context)
         {
             ArgumentNullException.ThrowIfNull(context);
-            if (context.Items is null)
-                throw new ExecutionContextNotFoundException();
 
-            if (!context.Items.ContainsKey(HandlerKey))
-                context.Items.Add(HandlerKey, new List<MapsRegistrationHandler>());
-
-            requests = (ICollection<MapsRegistrationHandler>)context.Items[HandlerKey]!;
+            requests = context.GetOrAddItemsList<MapsRegistrationHandler>(HandlerKey);
 
             lock (((ICollection)requests).SyncRoot)
                 requests.Add(this);
@@ -69,10 +64,9 @@ namespace Etherna.MongODM.Core.Utility
             /* Invoked by the driver while it looks up the conventions of a class map, from any
              * flow of the process: without an execution context there is no MongODM registration
              * in progress, and reporting it is the answer, not an error. */
-            if (context.Items is null ||
-                !context.Items.TryGetValue(HandlerKey, out var requestsObj))
+            var requests = context.TryGetItemsList<MapsRegistrationHandler>(HandlerKey);
+            if (requests is null)
                 return false;
-            var requests = (ICollection<MapsRegistrationHandler>)requestsObj!;
 
             lock (((ICollection)requests).SyncRoot)
                 return requests.Count != 0;


### PR DESCRIPTION
Closes [MODM-260](https://etherna.atlassian.net/browse/MODM-260).

## What the issue asked

The `MapsRegistrationHandler` constructor claimed its bookkeeping list with direct, unlocked
`ContainsKey`/`Add`/indexer accesses on `context.Items` (only the inner list add took a lock), and
the static `IsRegisteringMaps` read the dictionary the same way.

Every other handler (`DbExecutionContextHandler`, `DbSessionHandler`, `DryRunHandler`,
`ExclusiveAccessHandler`, `NewReferredModelsCollector`, the serializer modifiers) claims through
`ExecutionContextExtensions.GetOrAddItemsList` and reads through `TryGetItemsList`, which lock on the
non thread safe dictionary instance — the discipline the architecture documents: every library
access to that dictionary locks on its instance.

No reachable failure is known today: maps registration runs on a single flow at engine build. The
value of the fix is restoring the documented invariant, so a future flow sharing the execution
context can't corrupt the dictionary through this one handler.

## The change

The constructor claims with `GetOrAddItemsList`, the static check reads with `TryGetItemsList`, like
the sibling handlers do. The `ExecutionContextNotFoundException` on a missing context is preserved by
the shared extension, and stays where it was: raised by the construction, while the static read keeps
answering `false` — the driver invokes it from any flow of the process looking up class map
conventions, and a flow without an execution context is not registering maps.

## Tests

None added. `MapsRegistrationHandlerTest` already pins both behaviors this rewrite could break:
`HandlerMarksOnlyItsOwnScope` (claim, read, dispose) and `MissingExecutionContextRegistersNoMaps`,
which asserts together the tolerant read and the constructor throw. A test on the locking itself
would discriminate nothing: the defect has no reachable case a green suite could miss.

## Verification

Full solution build in Release, 0 warnings on net8.0, net9.0 and net10.0. Full test suite green:
351 core unit tests, 5 generator, 86 dashboard, 189 integration against a real MongoDB.

[MODM-260]: https://etherna.atlassian.net/browse/MODM-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ