### PR TITLE
Share one factory for the default model map creation

### DIFF
--- a/src/MongODM.Core/Serialization/Mapping/MapRegistry.cs
+++ b/src/MongODM.Core/Serialization/Mapping/MapRegistry.cs
@@ -24,7 +24,6 @@ using Etherna.MongODM.Core.Utility;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
@@ -319,46 +318,6 @@ namespace Etherna.MongODM.Core.Serialization.Mapping
         }
 
         // Helpers.
-        private ModelMap CreateNewDefaultModelMap(Type modelType)
-        {
-            // Construct.
-            //model schema
-            var modelMapDefinition = typeof(ModelMap<>);
-            var modelMapType = modelMapDefinition.MakeGenericType(modelType);
-
-            var modelMap = (ModelMap)Activator.CreateInstance(
-                modelMapType,
-                dbContextEngine)!;          //IDbContextEngine dbContextEngine
-
-            //class map
-            var classMapDefinition = typeof(BsonClassMap<>);
-            var classMapType = classMapDefinition.MakeGenericType(modelType);
-
-            var classMap = (BsonClassMap)Activator.CreateInstance(classMapType)!;
-
-            //model map
-            var modelMapSchemaDefinition = typeof(ModelMapSchema<>);
-            var modelMapSchemaType = modelMapSchemaDefinition.MakeGenericType(modelType);
-
-            var activeModelMapSchema = (ModelMapSchema)Activator.CreateInstance(
-                modelMapSchemaType,
-                BindingFlags.NonPublic | BindingFlags.Instance,
-                null,
-                [
-                    Guid.NewGuid().ToString(), //string id
-                    classMap,                  //BsonClassMap<TModel> bsonClassMap
-                    null!,                     //string? baseSchemaId
-                    null!,                     //Func<IDbContext, TModel, Task<TModel>>? fixDeserializedModelFunc
-                    modelMap                   //IModelMap modelMap
-                ],
-                CultureInfo.InvariantCulture)!;
-
-            // Set active model map.
-            modelMap.ActiveSchema = activeModelMapSchema;
-
-            return modelMap;
-        }
-
         private static string GetMemberMapElementPath(IMemberMap memberMap) => memberMap.RenderElementPath(false, _ => ".$", _ => ".*");
 
         /* Class map serializers write the full document of their model: the driver ones
@@ -488,7 +447,7 @@ namespace Etherna.MongODM.Core.Serialization.Mapping
                     if (!_maps.TryGetValue(baseModelType, out IMap? baseMap))
                     {
                         // Create schema instance.
-                        baseMap = CreateNewDefaultModelMap(baseModelType);
+                        baseMap = ModelMap.CreateNewDefault(dbContextEngine, baseModelType);
 
                         // Register schema instance.
                         _maps.Add(baseModelType, baseMap);

--- a/src/MongODM.Core/Serialization/Mapping/ModelMap.cs
+++ b/src/MongODM.Core/Serialization/Mapping/ModelMap.cs
@@ -17,7 +17,9 @@ using Etherna.MongODM.Core.Serialization.Serializers;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Etherna.MongODM.Core.Serialization.Mapping
@@ -108,6 +110,41 @@ namespace Etherna.MongODM.Core.Serialization.Mapping
         }
 
         // Internal methods.
+        /// <summary>
+        /// Build the default model map of a type: an active schema with a generated id, over a
+        /// plain class map, without a base schema nor a post-load fix function.
+        /// </summary>
+        /// <param name="dbContextEngine">The db context engine owning the map</param>
+        /// <param name="modelType">The mapped model type</param>
+        /// <returns>The new model map</returns>
+        internal static ModelMap CreateNewDefault(IDbContextEngine dbContextEngine, Type modelType)
+        {
+            //model map
+            var modelMap = (ModelMap)Activator.CreateInstance(
+                typeof(ModelMap<>).MakeGenericType(modelType),
+                dbContextEngine)!;          //IDbContextEngine dbContextEngine
+
+            //class map
+            var classMap = (BsonClassMap)Activator.CreateInstance(
+                typeof(BsonClassMap<>).MakeGenericType(modelType))!;
+
+            //active schema
+            modelMap.ActiveSchema = (ModelMapSchema)Activator.CreateInstance(
+                typeof(ModelMapSchema<>).MakeGenericType(modelType),
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                null,
+                [
+                    Guid.NewGuid().ToString(), //string id
+                    classMap,                  //BsonClassMap<TModel> bsonClassMap
+                    null!,                     //string? baseSchemaId
+                    null!,                     //Func<IDbContext, TModel, Task<TModel>>? fixDeserializedModelFunc
+                    modelMap                   //IModelMap modelMap
+                ],
+                CultureInfo.InvariantCulture)!;
+
+            return modelMap;
+        }
+
         internal void InitializeMemberMaps()
         {
             foreach (var schema in SchemasById.Values)

--- a/src/MongODM.Core/Serialization/Serializers/ReferenceSerializerConfiguration.cs
+++ b/src/MongODM.Core/Serialization/Serializers/ReferenceSerializerConfiguration.cs
@@ -20,9 +20,7 @@ using Etherna.MongODM.Core.Serialization.Mapping;
 using Etherna.MongODM.Core.Utility;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using System.Reflection;
 
 namespace Etherna.MongODM.Core.Serialization.Serializers
 {
@@ -230,45 +228,6 @@ namespace Etherna.MongODM.Core.Serialization.Serializers
         }
 
         // Helpers
-        private ModelMap CreateNewDefaultModelMap(Type modelType)
-        {
-            //model schema
-            var modelSchemaDefinition = typeof(ModelMap<>);
-            var modelSchemaType = modelSchemaDefinition.MakeGenericType(modelType);
-
-            var modelSchema = (ModelMap)Activator.CreateInstance(
-                modelSchemaType,
-                dbContextEngine)!;          //IDbContextEngine dbContextEngine
-
-            //class map
-            var classMapDefinition = typeof(BsonClassMap<>);
-            var classMapType = classMapDefinition.MakeGenericType(modelType);
-
-            var classMap = (BsonClassMap)Activator.CreateInstance(classMapType)!;
-
-            //model map
-            var modelMapSchemaDefinition = typeof(ModelMapSchema<>);
-            var modelMapSchemaType = modelMapSchemaDefinition.MakeGenericType(modelType);
-
-            var activeModelMapSchema = (ModelMapSchema)Activator.CreateInstance(
-                modelMapSchemaType,
-                BindingFlags.NonPublic | BindingFlags.Instance,
-                null,
-                [
-                    Guid.NewGuid().ToString(), //string id
-                    classMap,                  //BsonClassMap<TModel> bsonClassMap
-                    null!,                     //string? baseSchemaId
-                    null!,                     //Func<IDbContext, TModel, Task<TModel>>? fixDeserializedModelFunc
-                    modelSchema                //IModelSchema schema
-                ],
-                CultureInfo.InvariantCulture)!;
-
-            // Set active model map.
-            modelSchema.ActiveSchema = activeModelMapSchema;
-
-            return modelSchema;
-        }
-
         private static IEnumerable<string> GetSummaryLoadedMemberNamesHelper(
             IModelMapSchema modelMapSchema,
             BsonDocument referenceDocument) =>
@@ -300,7 +259,7 @@ namespace Etherna.MongODM.Core.Serialization.Serializers
                 if (!_modelMaps.TryGetValue(baseModelType, out IModelMap? baseModelMap))
                 {
                     // Create schema instance.
-                    baseModelMap = CreateNewDefaultModelMap(baseModelType);
+                    baseModelMap = ModelMap.CreateNewDefault(dbContextEngine, baseModelType);
 
                     // Register schema instance.
                     _modelMaps.Add(baseModelType, baseModelMap);


### PR DESCRIPTION
Closes [MODM-261](https://etherna.atlassian.net/browse/MODM-261).

## What the issue asked

`MapRegistry.CreateNewDefaultModelMap` and its copy in `ReferenceSerializerConfiguration` were
identical modulo local variable names — the reference copy even carried stale naming
(`modelSchema`, the comment `//IModelSchema schema`), showing it had stopped following the original
some renames ago. Two places tracking the reflective `ModelMapSchema<>` non public constructor
signature, with nothing making them fail together when it changes.

## The change

One shared `internal static ModelMap.CreateNewDefault(dbContextEngine, modelType)`, on the type it
builds, called by both base map link walks: an active schema with a generated id, over a plain class
map, without a base schema nor a post-load fix function.

The two link walks stay separate, as the issue asked: they differ semantically — the `typeof(object)`
cutoff belongs to the registry one only, and the linking is per-schema there against per-map in the
reference configuration — and are not part of the duplication.

The extracted body collapses the `definition` + `MakeGenericType` pairs into single expressions and
assigns the schema straight to `ActiveSchema`, being new code. The orphaned imports go with it:
`System.Globalization` from `MapRegistry`, `System.Globalization` and `System.Reflection` from
`ReferenceSerializerConfiguration`.

Win: 45 lines, and a single place tracking that constructor signature.

## Tests

None added. Both paths are already covered by `MapRegistryTest` and
`ReferenceSerializerConfigurationTest`, which exercise the default base map creation inside their
respective linking: this is a semantics preserving extraction, and a test on the factory would
discriminate nothing those suites don't already catch.

## Verification

Full solution build in Release, 0 warnings on net8.0, net9.0 and net10.0. Full test suite green:
351 core unit tests, 5 generator, 86 dashboard, 189 integration against a real MongoDB.

[MODM-261]: https://etherna.atlassian.net/browse/MODM-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ