### PR TITLE
Share the array filter rendering between the dependencies update and the reference removal

### DIFF
--- a/src/MongODM.Core/Serialization/Mapping/MemberMapRenderHelper.cs
+++ b/src/MongODM.Core/Serialization/Mapping/MemberMapRenderHelper.cs
@@ -12,6 +12,7 @@
 // You should have received a copy of the GNU Lesser General Public License along with MongODM.
 // If not, see <https://www.gnu.org/licenses/>.
 
+using Etherna.MongODM.Core.Exceptions;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -22,6 +23,13 @@ namespace Etherna.MongODM.Core.Serialization.Mapping
 {
     public static class MemberMapRenderHelper
     {
+        // Consts.
+        /// <summary>
+        /// Name of the array filter addressing the array items hosting a referenced id.
+        /// </summary>
+        internal const string ArrayFilterName = "idfilter";
+
+        // Methods.
         [SuppressMessage("Performance", "CA1851:Possible multiple enumerations of \'IEnumerable\' collection")]
         public static string RenderElementPath(
             IEnumerable<IMemberMap> memberMapsPath,
@@ -80,6 +88,74 @@ namespace Etherna.MongODM.Core.Serialization.Mapping
             }
 
             return sb.ToString();
+        }
+
+        // Internals.
+        /// <summary>
+        /// The undefined array index symbol selector of an update field path: every array level
+        /// above the filtered one addresses all its positions, the filtered one addresses the
+        /// items selected by the array filter.
+        /// </summary>
+        /// <param name="lastUndefinedArrayElement">The array level the array filter addresses</param>
+        /// <returns>The symbol selector</returns>
+        internal static Func<ArrayElementRepresentation, string> BuildArrayFilterFieldSelector(
+            ArrayElementRepresentation? lastUndefinedArrayElement) =>
+            arrayElement => arrayElement != lastUndefinedArrayElement ?
+                ".$[]" :                  //select all array items
+                $".$[{ArrayFilterName}]"; //else, filter in array items
+
+        /// <summary>
+        /// The last array element with an undefined index on the element path of a member map:
+        /// the array level an update filters on the items hosting the referenced id.
+        /// </summary>
+        /// <param name="memberMap">The member map addressed by the update</param>
+        /// <returns>The array element, or null when its path crosses no such array</returns>
+        internal static ArrayElementRepresentation? FindLastUndefinedArrayElement(IMemberMap memberMap)
+        {
+            ArgumentNullException.ThrowIfNull(memberMap);
+
+            return memberMap.MemberMapPath
+                .SelectMany(mm => mm.InternalElementPath
+                    .OfType<ArrayElementRepresentation>()
+                    .Where(arrayElement => arrayElement.ItemIndex is null))
+                .LastOrDefault();
+        }
+
+        /// <summary>
+        /// The path addressing the referenced id inside the array items selected by the array
+        /// filter, prefixed by the filter name.
+        /// </summary>
+        /// <param name="idMemberMap">The id member map of the reference</param>
+        /// <param name="lastUndefinedArrayElement">The array level the array filter addresses</param>
+        /// <returns>The array filter id path</returns>
+        internal static string RenderArrayFilterIdPath(
+            IMemberMap idMemberMap,
+            ArrayElementRepresentation lastUndefinedArrayElement)
+        {
+            ArgumentNullException.ThrowIfNull(idMemberMap);
+            ArgumentNullException.ThrowIfNull(lastUndefinedArrayElement);
+
+            return $"{ArrayFilterName}{string.Join(".",
+                idMemberMap.MemberMapPath
+                    .SkipWhile(mm => mm != lastUndefinedArrayElement.MemberMap) //take all final member maps in path from the last with undefined array index
+                    .Select(mm =>
+                    {
+                        //if is the member map hosting the filtered array, render internal path only after it
+                        var internalElementPathToRender = mm.InternalElementPath;
+                        if (mm == lastUndefinedArrayElement.MemberMap)
+                            internalElementPathToRender = internalElementPathToRender.Reverse()
+                                                                                     .TakeWhile(element => element != lastUndefinedArrayElement)
+                                                                                     .Reverse();
+
+                        var renderedInternalElementPath = RenderInternalItemElementPath(
+                            internalElementPathToRender,
+                            _ => throw new MongodmElementPathRenderingException("Can't exist arrays with undefined index here"),
+                            _ => throw new MongodmElementPathRenderingException("Can't render field with an unknown document key in path"));
+
+                        return mm != lastUndefinedArrayElement.MemberMap ?
+                            mm.BsonMemberMap.ElementName + renderedInternalElementPath :
+                            renderedInternalElementPath;
+                    }))}";
         }
     }
 }

--- a/src/MongODM.Core/Serialization/Mapping/ReferenceRemovalShape.cs
+++ b/src/MongODM.Core/Serialization/Mapping/ReferenceRemovalShape.cs
@@ -27,9 +27,6 @@ namespace Etherna.MongODM.Core.Serialization.Mapping
     /// </summary>
     internal sealed class ReferenceRemovalShape
     {
-        // Consts.
-        private const string ArrayFilterName = "idfilter";
-
         // Fields.
         private readonly string? arrayFilterIdPath;
         private readonly string? pullFieldPath;
@@ -132,45 +129,17 @@ namespace Etherna.MongODM.Core.Serialization.Mapping
             else
             {
                 // The reference is a single valued element: removing it sets it to null.
-                /* Mirror the dependencies update task rendering: every array level above the
-                 * reference addresses all its positions, except the last one, filtered on the
-                 * items nesting the referenced id. */
-                var lastUndefinedArrayElement = referenceMemberMap.MemberMapPath
-                    .SelectMany(memberMap => memberMap.InternalElementPath
-                        .OfType<ArrayElementRepresentation>()
-                        .Where(arrayElement => arrayElement.ItemIndex is null))
-                    .LastOrDefault();
+                /* Every array level above the reference addresses all its positions, except
+                 * the last one, filtered on the items nesting the referenced id. */
+                var lastUndefinedArrayElement = MemberMapRenderHelper.FindLastUndefinedArrayElement(referenceMemberMap);
 
                 setFieldPath = referenceMemberMap.RenderElementPath(
                     referToFinalItem: true,
-                    undefArrayElement =>
-                        undefArrayElement != lastUndefinedArrayElement ?
-                        ".$[]" :
-                        $".$[{ArrayFilterName}]",
+                    MemberMapRenderHelper.BuildArrayFilterFieldSelector(lastUndefinedArrayElement),
                     _ => throw new MongodmElementPathRenderingException("Can't render field with an unknown document key in path"));
 
                 if (lastUndefinedArrayElement is not null)
-                    arrayFilterIdPath = $"{ArrayFilterName}{string.Join(".",
-                        idMemberMap.MemberMapPath
-                            .SkipWhile(memberMap => memberMap != lastUndefinedArrayElement.MemberMap)
-                            .Select(memberMap =>
-                            {
-                                //if is the member map hosting the filtered array, render internal path only after it
-                                var internalElementPathToRender = memberMap.InternalElementPath;
-                                if (memberMap == lastUndefinedArrayElement.MemberMap)
-                                    internalElementPathToRender = internalElementPathToRender.Reverse()
-                                                                                             .TakeWhile(element => element != lastUndefinedArrayElement)
-                                                                                             .Reverse();
-
-                                var renderedInternalElementPath = MemberMapRenderHelper.RenderInternalItemElementPath(
-                                    internalElementPathToRender,
-                                    _ => throw new MongodmElementPathRenderingException("Can't exist arrays with undefined index here"),
-                                    _ => throw new MongodmElementPathRenderingException("Can't render field with an unknown document key in path"));
-
-                                return memberMap != lastUndefinedArrayElement.MemberMap ?
-                                    memberMap.BsonMemberMap.ElementName + renderedInternalElementPath :
-                                    renderedInternalElementPath;
-                            }))}";
+                    arrayFilterIdPath = MemberMapRenderHelper.RenderArrayFilterIdPath(idMemberMap, lastUndefinedArrayElement);
             }
 
             return new ReferenceRemovalShape(

--- a/src/MongODM.Core/Tasks/UpdateDocDependenciesTask.cs
+++ b/src/MongODM.Core/Tasks/UpdateDocDependenciesTask.cs
@@ -244,19 +244,12 @@ namespace Etherna.MongODM.Core.Tasks
             var filter = new MemberMapEqFilterDefinition<TOriginModel, object>(idMemberMap, referencedModelId);
 
             // Define update operator.
-            var lastUndefinedArrayElement = subDocumentMemberMap.MemberMapPath
-                .SelectMany(mm => mm.InternalElementPath
-                    .OfType<ArrayElementRepresentation>()
-                    .Where(arrayElement => arrayElement.ItemIndex is null))
-                .LastOrDefault();
+            var lastUndefinedArrayElement = MemberMapRenderHelper.FindLastUndefinedArrayElement(subDocumentMemberMap);
 
             var update = Builders<TOriginModel>.Update.Set(
                 new MemberMapFieldDefinition<TOriginModel, BsonDocument>(
                     subDocumentMemberMap,
-                    undefArrayElement =>
-                        undefArrayElement != lastUndefinedArrayElement ? //if isn't the last array element with undefined index
-                        ".$[]" :                                         //select all array items
-                        ".$[idfilter]",                                  //else, filter in array items
+                    MemberMapRenderHelper.BuildArrayFilterFieldSelector(lastUndefinedArrayElement),
                     _ => throw new MongodmElementPathRenderingException("Can't render field with an unknown document key in path"),
                     referToFinalItem: true),
                 updatedSubDocument);
@@ -264,29 +257,8 @@ namespace Etherna.MongODM.Core.Tasks
             var arrayFilters = new List<ArrayFilterDefinition>();
             if (lastUndefinedArrayElement is not null)
                 arrayFilters.Add(new BsonDocumentArrayFilterDefinition<BsonDocument>(
-                    new BsonDocument($"idfilter{string.Join(".",
-                        idMemberMap.MemberMapPath
-                            .SkipWhile(mm => mm != lastUndefinedArrayElement.MemberMap) //take all final member maps in path from the last with undefined array index
-                            .Select(mm =>
-                            {
-                                //if is the last member map, render internal path only after the last undefined array index
-                                var internalElementPathToRender = mm.InternalElementPath;
-                                if (mm == lastUndefinedArrayElement.MemberMap)
-                                    internalElementPathToRender = internalElementPathToRender.Reverse()
-                                                                                             .TakeWhile(e => e != lastUndefinedArrayElement)
-                                                                                             .Reverse();
-
-                                var renderedInternalElementPath = MemberMapRenderHelper.RenderInternalItemElementPath(
-                                    internalElementPathToRender,
-                                    _ => throw new MongodmElementPathRenderingException("Can't exist arrays with undefined index here"),
-                                    _ => throw new MongodmElementPathRenderingException("Can't render field with an unknown document key in path"));
-
-                                var returnedString = mm != lastUndefinedArrayElement.MemberMap ?
-                                    mm.BsonMemberMap.ElementName + renderedInternalElementPath :
-                                    renderedInternalElementPath;
-
-                                return returnedString;
-                            }))}",
+                    new BsonDocument(
+                        MemberMapRenderHelper.RenderArrayFilterIdPath(idMemberMap, lastUndefinedArrayElement),
                         new BsonDocument("$eq", updatedSubDocument.GetValue(idMemberMap.BsonMemberMap.ElementName)))));
 
             // Exec update.


### PR DESCRIPTION
Closes [MODM-262](https://etherna.atlassian.net/browse/MODM-262).

## What the issue asked

`UpdateDocDependenciesTask` and `ReferenceRemovalShape` hand-mirrored three semantically identical
pieces of the array filter rendering: the selection of the last undefined array element on the path,
the `.$[]` / `.$[idfilter]` field path selector, and the array filter id path computation. The shape
admitted the coupling in a comment — "Mirror the dependencies update task rendering" — and the
`idfilter` literal was a const in one file and a magic string in the other.

## The change

The three pieces move into `MemberMapRenderHelper`, with one shared const for the filter name:

- `ArrayFilterName`, the `idfilter` const;
- `FindLastUndefinedArrayElement(memberMap)`;
- `BuildArrayFilterFieldSelector(lastUndefinedArrayElement)`;
- `RenderArrayFilterIdPath(idMemberMap, lastUndefinedArrayElement)`.

The issue prescribed two helpers plus the const, listing the field path selector among the identical
pieces: the selector is extracted too, because sharing the const alone would leave its ternary
written twice and the pairing between "which array level is filtered" and "how the filter is named"
implicit. With all three, the sequence — find the array level, render the selector, render the id
path — is held together by the signatures instead of by a comment, which is what the issue asked for.

All of them are `internal`: they encode the update shape of the library's own tasks, not something an
application composes, so the public surface of the helper stays unchanged. They live in an
`// Internals.` section, after the public methods.

The obsolete "Mirror the dependencies update task rendering" note goes: it is not a mirror anymore,
it is the same code.

Win: 30 lines at the two call sites, and an invariant the compiler now enforces.

## Tests

None added. This is a semantics preserving extraction, and both paths are already pinned end to end
by `UpdateDocDependenciesTests`, `DeleteDocDependenciesTests` and `MissingOriginReferencesTests`,
which exercise the array filter updates over references nested in arrays.

## Verification

Full solution build in Release, 0 warnings on net8.0, net9.0 and net10.0. Full test suite green:
351 core unit tests, 5 generator, 86 dashboard, 189 integration against a real MongoDB.

[MODM-262]: https://etherna.atlassian.net/browse/MODM-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ