### PR TITLE
Extract the single element serialization idiom into a serializer extension

### DIFF
--- a/src/MongODM.Core/Extensions/BsonSerializerExtensions.cs
+++ b/src/MongODM.Core/Extensions/BsonSerializerExtensions.cs
@@ -1,0 +1,54 @@
+// Copyright 2020-present Etherna SA
+// This file is part of MongODM.
+// 
+// MongODM is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// 
+// MongODM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License along with MongODM.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Etherna.MongoDB.Bson;
+using Etherna.MongoDB.Bson.IO;
+using Etherna.MongoDB.Bson.Serialization;
+using System;
+
+namespace Etherna.MongODM.Core.Extensions
+{
+    internal static class BsonSerializerExtensions
+    {
+        // Consts.
+        private const string WrapperElementName = "value";
+
+        // Methods.
+        /// <summary>
+        /// Serialize a value apart from any document.
+        /// </summary>
+        /// <remarks>
+        /// A serializer writes its value as an element of a document, so serializing one apart
+        /// needs a wrapper document hosting it: the value is the element written into it.
+        /// </remarks>
+        /// <param name="serializer">The serializer of the value</param>
+        /// <param name="value">The value to serialize</param>
+        /// <returns>The serialized value</returns>
+        public static BsonValue SerializeToBsonValue(this IBsonSerializer serializer, object? value)
+        {
+            ArgumentNullException.ThrowIfNull(serializer);
+
+            var wrapper = new BsonDocument();
+            using (var bsonWriter = new BsonDocumentWriter(wrapper))
+            {
+                var context = BsonSerializationContext.CreateRoot(bsonWriter);
+                bsonWriter.WriteStartDocument();
+                bsonWriter.WriteName(WrapperElementName);
+                serializer.Serialize(context, value);
+                bsonWriter.WriteEndDocument();
+            }
+            return wrapper[WrapperElementName];
+        }
+    }
+}

--- a/src/MongODM.Core/Repositories/Repository.cs
+++ b/src/MongODM.Core/Repositories/Repository.cs
@@ -13,7 +13,6 @@
 // If not, see <https://www.gnu.org/licenses/>.
 
 using Etherna.MongoDB.Bson;
-using Etherna.MongoDB.Bson.IO;
 using Etherna.MongoDB.Bson.Serialization;
 using Etherna.MongoDB.Driver;
 using Etherna.MongoDB.Driver.Linq;
@@ -698,7 +697,7 @@ namespace Etherna.MongODM.Core.Repositories
                         {
                             var memberValue = memberMap.Getter(castedModel);
                             var currentValue = memberMap.ShouldSerialize(castedModel, memberValue)
-                                ? SerializeMemberValue(memberMap, memberValue)
+                                ? memberMap.GetSerializer().SerializeToBsonValue(memberValue)
                                 : null;
                             var modelDocumentValue = modelDocument.TryGetValue(memberMap.ElementName, out var bv) ? bv : null;
 
@@ -926,15 +925,7 @@ namespace Etherna.MongODM.Core.Repositories
                 var serializer = DbContext.Engine.MapRegistry.GetMappedSerializer(typeof(TModel));
                 
                 // Serialize model.
-                var modelBsonDoc = new BsonDocument();
-                using (var bsonWriter = new BsonDocumentWriter(modelBsonDoc))
-                {
-                    var context = BsonSerializationContext.CreateRoot(bsonWriter);
-                    bsonWriter.WriteStartDocument();
-                    bsonWriter.WriteName("model");
-                    serializer.Serialize(context, onInsertModel);
-                    bsonWriter.WriteEndDocument();
-                }
+                var onInsertDocument = serializer.SerializeToBsonValue(onInsertModel).AsBsonDocument;
 
                 // Update "update" definition with OnInsert instructions.
                 var updatedPaths = updatedFields
@@ -942,7 +933,7 @@ namespace Etherna.MongODM.Core.Repositories
                     .Select(f => f.FieldName.Split('.'))
                     .ToArray();
                 var onInsertUpdate = ComposeOnInsertFields(
-                        modelBsonDoc[0].AsBsonDocument.Elements.Where(element => element.Name != IdElementName),
+                        onInsertDocument.Elements.Where(element => element.Name != IdElementName),
                         null,
                         updatedPaths)
                     .Select(field => Builders<TModel>.Update.SetOnInsert(field.Name, field.Value))
@@ -1351,13 +1342,9 @@ namespace Etherna.MongODM.Core.Repositories
             using var newModelsCollector = new NewReferredModelsCollector(DbContext.Engine.ExecutionContext);
             using (new DbExecutionContextHandler(DbContext))
             using (InternalDbContext.SuppressChangeTracking())
-            using (var bsonWriter = new BsonDocumentWriter([]))
             {
-                var context = BsonSerializationContext.CreateRoot(bsonWriter);
-                bsonWriter.WriteStartDocument();
-                bsonWriter.WriteName("model");
-                serializer.Serialize(context, model);
-                bsonWriter.WriteEndDocument();
+                //the serialized document is discarded: the pass runs for the collector reports
+                _ = serializer.SerializeToBsonValue(model);
             }
             return newModelsCollector.Models;
         }
@@ -1440,18 +1427,6 @@ namespace Etherna.MongODM.Core.Repositories
             }
         }
 
-        private static BsonValue SerializeMemberValue(BsonMemberMap memberMap, object? memberValue)
-        {
-            var document = new BsonDocument();
-            using var bsonWriter = new BsonDocumentWriter(document);
-            var context = BsonSerializationContext.CreateRoot(bsonWriter);
-            bsonWriter.WriteStartDocument();
-            bsonWriter.WriteName("value");
-            memberMap.GetSerializer().Serialize(context, memberValue);
-            bsonWriter.WriteEndDocument();
-            return document["value"];
-        }
-
         /* A document written with an id that doesn't render as an addressable filter value
          * couldn't be found, updated or deleted afterwards: build the id filter of the
          * inserting model, refusing the write the same way every other operation refuses
@@ -1493,17 +1468,8 @@ namespace Etherna.MongODM.Core.Repositories
                 return null;
 
             //reading the model members to serialize must not flag it a change candidate.
-            var wrapper = new BsonDocument();
             using (InternalDbContext.SuppressChangeTracking())
-            using (var bsonWriter = new BsonDocumentWriter(wrapper))
-            {
-                var context = BsonSerializationContext.CreateRoot(bsonWriter);
-                bsonWriter.WriteStartDocument();
-                bsonWriter.WriteName("model");
-                serializer.Serialize(context, model);
-                bsonWriter.WriteEndDocument();
-            }
-            return wrapper["model"].AsBsonDocument;
+                return serializer.SerializeToBsonValue(model).AsBsonDocument;
         }
 
         // Protected virtual methods.

--- a/src/MongODM.Core/Tasks/DeleteDocDependenciesTask.cs
+++ b/src/MongODM.Core/Tasks/DeleteDocDependenciesTask.cs
@@ -13,8 +13,6 @@
 // If not, see <https://www.gnu.org/licenses/>.
 
 using Etherna.MongoDB.Bson;
-using Etherna.MongoDB.Bson.IO;
-using Etherna.MongoDB.Bson.Serialization;
 using Etherna.MongoDB.Driver;
 using Etherna.MongODM.Core.Domain.Models;
 using Etherna.MongODM.Core.Extensions;
@@ -126,7 +124,7 @@ namespace Etherna.MongODM.Core.Tasks
                         .Max();
 
                     // Serialize the deleted id like the references store it.
-                    var deletedIdValue = SerializeReferencedId(representativeIdMemberMap, deletedModelId);
+                    var deletedIdValue = representativeIdMemberMap.Serializer.SerializeToBsonValue(deletedModelId);
 
                     await ((Task)propagateAsyncMethodInfo.Invoke(null,
                     [
@@ -189,18 +187,6 @@ namespace Etherna.MongODM.Core.Tasks
                 {
                     ArrayFilters = [new BsonDocumentArrayFilterDefinition<BsonDocument>(arrayFilter)]
                 }).ConfigureAwait(false);
-        }
-
-        private static BsonValue SerializeReferencedId(IMemberMap idMemberMap, object deletedModelId)
-        {
-            var document = new BsonDocument();
-            using var bsonWriter = new BsonDocumentWriter(document);
-            var context = BsonSerializationContext.CreateRoot(bsonWriter);
-            bsonWriter.WriteStartDocument();
-            bsonWriter.WriteName("id");
-            idMemberMap.Serializer.Serialize(context, deletedModelId);
-            bsonWriter.WriteEndDocument();
-            return document["id"];
         }
     }
 }


### PR DESCRIPTION
Closes [MODM-263](https://etherna.atlassian.net/browse/MODM-263).

## What the issue asked

The "serialize a value as one named element of a wrapper document" dance — `BsonDocumentWriter`,
`CreateRoot`, `WriteStartDocument`, `WriteName`, `Serialize`, `WriteEndDocument`, read the element
back — was repeated at five sites: `Repository.UpsertAsync`, `Repository.DiscoverNewReferredModels`,
`Repository.SerializeMemberValue`, `Repository.TrySerializeModelBsonDocument` and
`DeleteDocDependenciesTask.SerializeReferencedId`. Five copies of the same rite, each naming the
wrapper element as it liked (`model`, `value`, `id`), and none saying why a wrapper is needed at all.

## The change

One internal extension, `IBsonSerializer.SerializeToBsonValue(value)` in
`Extensions/BsonSerializerExtensions.cs`, returning the element value, with the why-a-wrapper
explanation written once in its remarks: a serializer writes its value as an element of a document,
so serializing one apart needs a wrapper document hosting it.

With the extension in place `SerializeMemberValue` and `SerializeReferencedId`, one call site each,
inline away per the no-single-call-site-helper rule; `TrySerializeModelBsonDocument` stays, it has
three.

In `DiscoverNewReferredModels` the serialized document is discarded — the pass runs for the ambient
collector reports — so the call keeps an explicit `_ =` discard and a comment saying so, instead of a
result vanishing silently.

The orphaned imports go with it, verified by compiling: `Etherna.MongoDB.Bson.IO` from both files,
and `Etherna.MongoDB.Bson.Serialization` from `DeleteDocDependenciesTask`.

Win: 48 lines at the call sites.

## Tests

None added. This is a semantics preserving extraction, and the five sites all sit on paths the suites
already exercise densely: upserts, member level saves, new referred models auto creation, delete
propagation.

## Verification

Full solution build in Release, 0 warnings on net8.0, net9.0 and net10.0. Full test suite green:
351 core unit tests, 5 generator, 86 dashboard, 189 integration against a real MongoDB.

[MODM-263]: https://etherna.atlassian.net/browse/MODM-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ