### PR TITLE
Tolerate a missing execution context in the dry run check

### DIFF
--- a/src/MongODM.Core/Utility/DbMaintainer.cs
+++ b/src/MongODM.Core/Utility/DbMaintainer.cs
@@ -63,8 +63,7 @@ namespace Etherna.MongODM.Core.Utility
             var deletedModelId = ((IEntityModel<TKey>)deletedModel).Id!;
 
             // Skip the propagation on a dry run: simulated writes don't alter any document.
-            if (dbContextEngine.ExecutionContext.Items is not null &&
-                DryRunHandler.IsDryRunEnabled(dbContextEngine.ExecutionContext))
+            if (DryRunHandler.IsDryRunEnabled(dbContextEngine.ExecutionContext))
             {
                 logger.DbMaintainerSkippedDependenciesDeleteOnDryRun(
                     dbContextEngine.Options.DbName,
@@ -196,8 +195,7 @@ namespace Etherna.MongODM.Core.Utility
                 throw new ArgumentException($"Model is not of type {nameof(IEntityModel<TKey>)}", nameof(updatedModel));
 
             // Skip the propagation on a dry run: simulated writes don't alter any document.
-            if (dbContextEngine.ExecutionContext.Items is not null &&
-                DryRunHandler.IsDryRunEnabled(dbContextEngine.ExecutionContext))
+            if (DryRunHandler.IsDryRunEnabled(dbContextEngine.ExecutionContext))
             {
                 logger.DbMaintainerSkippedDependenciesUpdateOnDryRun(
                     dbContextEngine.Options.DbName,

--- a/src/MongODM.Core/Utility/DryRunHandler.cs
+++ b/src/MongODM.Core/Utility/DryRunHandler.cs
@@ -13,7 +13,6 @@
 // If not, see <https://www.gnu.org/licenses/>.
 
 using Etherna.MongODM.Core.ExecContext;
-using Etherna.MongODM.Core.ExecContext.Exceptions;
 using Etherna.MongODM.Core.Extensions;
 using System;
 using System.Collections;
@@ -52,9 +51,9 @@ namespace Etherna.MongODM.Core.Utility
         // Static methods.
         public static bool IsDryRunEnabled(IExecutionContext context)
         {
-            if (context.Items is null)
-                throw new ExecutionContextNotFoundException();
-
+            /* Invoked also from flows without an execution context, like any db operation run
+             * outside a MongODM scope: such a flow is not a dry run, and reporting it is the
+             * answer, not an error. */
             var requests = context.TryGetItemsList<DryRunHandler>(HandlerKey);
             if (requests is null)
                 return false;

--- a/src/MongODM.Core/Utility/LimitedAccessMongoCollection.cs
+++ b/src/MongODM.Core/Utility/LimitedAccessMongoCollection.cs
@@ -1203,7 +1203,6 @@ namespace Etherna.MongODM.Core.Utility
         }
 
         private bool IsDryRun() =>
-            dbContextEngine.ExecutionContext.Items is not null &&
             DryRunHandler.IsDryRunEnabled(dbContextEngine.ExecutionContext);
 
         private BulkWriteResult<TDocument> SimulateBulkWrite(IEnumerable<WriteModel<TDocument>> requests)

--- a/src/MongODM.Core/Utility/LimitedAccessMongoDatabase.cs
+++ b/src/MongODM.Core/Utility/LimitedAccessMongoDatabase.cs
@@ -575,8 +575,7 @@ namespace Etherna.MongODM.Core.Utility
 
         private void VerifyDryRunSimulable(string operationDescription)
         {
-            if (dbContextEngine.ExecutionContext.Items is not null &&
-                DryRunHandler.IsDryRunEnabled(dbContextEngine.ExecutionContext))
+            if (DryRunHandler.IsDryRunEnabled(dbContextEngine.ExecutionContext))
                 throw new InvalidOperationException($"{operationDescription} can't be simulated by a dry run");
         }
     }


### PR DESCRIPTION
Closes [MODM-264](https://etherna.atlassian.net/browse/MODM-264).

## What the issue asked

`DryRunHandler.IsDryRunEnabled` threw `ExecutionContextNotFoundException` when `context.Items` was
null, but the throw was unreachable: all four callers pre-checked `Items is not null` before invoking
it (`DbMaintainer` at two sites, `LimitedAccessMongoCollection`, `LimitedAccessMongoDatabase`), each
re-encoding the real semantics — a flow without an execution context is not a dry run — and the guard
existed only to force them to.

## The change

`IsDryRunEnabled` returns `false` on a null `Items`, and the four caller pre-checks go: the semantics
lives in one place and the callers become one-liners.

This deliberately deviates from the throwing convention of the sibling handlers, and the comment says
so: here the tolerant reading is what every caller already implements, and keeping the throw only
forces the duplicated guards. The constructor stays intransigent — building a handler without a
context is a real error — and keeps throwing through `GetOrAddItemsList`.

The orphaned `ExecContext.Exceptions` import goes with it.

## Tests

None added. From the outside the behavior is identical, because the caller pre-checks already short
circuited: there is nothing new to pin, and an indirect test would pin something that didn't change.

The non-regression coverage is proved by mutation instead: putting the throw back into
`IsDryRunEnabled`, with the pre-checks removed, fails 4 existing tests.
`LimitedAccessMongoCollectionTest` has 23 tests of which only 5 initialize an async local context, so
18 run without an execution context and exercise exactly the path the pre-check used to cover. The
tolerant contract is already pinned by the suite.

## Verification

Full solution build in Release, 0 warnings on net8.0, net9.0 and net10.0. Full test suite green:
351 core unit tests, 5 generator, 86 dashboard, 189 integration against a real MongoDB.

[MODM-264]: https://etherna.atlassian.net/browse/MODM-264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ