### PR TITLE
Minor cleanups in the core package

### DIFF
--- a/src/MongODM.Core/DbContext.cs
+++ b/src/MongODM.Core/DbContext.cs
@@ -780,11 +780,9 @@ namespace Etherna.MongODM.Core
                 if (modelSourceRepositories.TryGetValue(model, out var trackedRepository))
                     return trackedRepository;
 
-            return TryGetRepositoryForModelType(engine.ProxyGenerator.PurgeProxyType(model.GetType()));
+            return scopedRepositoryRegistry?.TryGetRepositoryByHandledModelType(
+                engine.ProxyGenerator.PurgeProxyType(model.GetType()));
         }
-
-        private IRepository? TryGetRepositoryForModelType(Type modelType) =>
-            scopedRepositoryRegistry?.TryGetRepositoryByHandledModelType(modelType);
 
         private MemberInfo? TryGetIdMemberInfo(Type modelType)
         {

--- a/src/MongODM.Core/Extensions/BsonSerializerExtensions.cs
+++ b/src/MongODM.Core/Extensions/BsonSerializerExtensions.cs
@@ -16,6 +16,7 @@ using Etherna.MongoDB.Bson;
 using Etherna.MongoDB.Bson.IO;
 using Etherna.MongoDB.Bson.Serialization;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Etherna.MongODM.Core.Extensions
 {
@@ -49,6 +50,45 @@ namespace Etherna.MongODM.Core.Extensions
                 bsonWriter.WriteEndDocument();
             }
             return wrapper[WrapperElementName];
+        }
+
+        /// <summary>
+        /// Unwrap a container serializer to the serializer of the values it wraps: the value
+        /// serializer of a dictionary, or the item serializer of an array.
+        /// </summary>
+        /// <remarks>
+        /// Several serializers implement the container interfaces also when they can't provide
+        /// the required information, so the dictionary is tried first: the array unwrap of a
+        /// dictionary would stop on its key value pair serializer, which wraps no value.
+        /// </remarks>
+        /// <param name="serializer">The serializer to unwrap</param>
+        /// <param name="childSerializer">The serializer of the wrapped values</param>
+        /// <returns>True if the serializer wraps values into a container</returns>
+        public static bool TryGetContainerChildSerializer(
+            this IBsonSerializer serializer,
+            [MaybeNullWhen(false)] out IBsonSerializer childSerializer)
+        {
+            ArgumentNullException.ThrowIfNull(serializer);
+
+            if (serializer is IBsonDictionarySerializer dictionarySerializer)
+            {
+                try
+                {
+                    childSerializer = dictionarySerializer.ValueSerializer;
+                    return true;
+                }
+                catch { }
+            }
+
+            if (serializer is IBsonArraySerializer arraySerializer &&
+                arraySerializer.TryGetItemSerializationInfo(out var itemSerializationInfo))
+            {
+                childSerializer = itemSerializationInfo.Serializer;
+                return true;
+            }
+
+            childSerializer = null;
+            return false;
         }
     }
 }

--- a/src/MongODM.Core/Extensions/MemberMapExtensions.cs
+++ b/src/MongODM.Core/Extensions/MemberMapExtensions.cs
@@ -41,24 +41,9 @@ namespace Etherna.MongODM.Core.Extensions
                 if (serializer is IReferenceSerializer referenceSerializer)
                     return referenceSerializer;
 
-                if (serializer is IBsonDictionarySerializer dictionarySerializer)
-                {
-                    try
-                    {
-                        serializer = dictionarySerializer.ValueSerializer;
-                        continue;
-                    }
-                    catch { }
-                }
-
-                if (serializer is IBsonArraySerializer arraySerializer &&
-                    arraySerializer.TryGetItemSerializationInfo(out var itemSerializationInfo))
-                {
-                    serializer = itemSerializationInfo.Serializer;
-                    continue;
-                }
-
-                break;
+                if (!serializer.TryGetContainerChildSerializer(out var childSerializer))
+                    break;
+                serializer = childSerializer;
             }
 
             return null;

--- a/src/MongODM.Core/Repositories/Repository.cs
+++ b/src/MongODM.Core/Repositories/Repository.cs
@@ -1013,6 +1013,56 @@ namespace Etherna.MongODM.Core.Repositories
                 [setField],
                 cancellationToken);
 
+        // Protected virtual methods.
+        protected virtual Task CreateOnDBAsync(IEnumerable<TModel> models, CancellationToken cancellationToken) =>
+            AccessToCollectionAsync(collection =>
+            {
+                foreach (var model in models)
+                    ThrowIfIdIsNotAddressable(model);
+
+                return collection.InsertManyAsync(models, null, cancellationToken);
+            });
+
+        protected virtual Task CreateOnDBAsync(TModel model, CancellationToken cancellationToken) =>
+            AccessToCollectionAsync(collection =>
+            {
+                ThrowIfIdIsNotAddressable(model);
+
+                return collection.InsertOneAsync(model, null, cancellationToken);
+            });
+
+        protected virtual Task DeleteOnDBAsync(
+            TModel model,
+            FilterDefinition<TModel>[] additionalFilters,
+            CancellationToken cancellationToken) =>
+            AccessToCollectionAsync(collection =>
+            {
+                ArgumentNullException.ThrowIfNull(model);
+
+                var idFilter = new EntityIdEqFilterDefinition<TModel, TKey>(model.Id);
+
+                return collection.DeleteOneAsync(
+                    additionalFilters.Length == 0 ?
+                        idFilter :
+                        Builders<TModel>.Filter.And(additionalFilters.Prepend(idFilter)),
+                    cancellationToken);
+            });
+
+        protected virtual async Task<TModel> FindOneOnDBAsync(TKey id, CancellationToken cancellationToken = default)
+        {
+            if (id == null)
+                throw new ArgumentNullException(nameof(id));
+
+            try
+            {
+                return await FindOneOnDBAsync(new EntityIdEqFilterDefinition<TModel, TKey>(id), cancellationToken).ConfigureAwait(false);
+            }
+            catch (MongodmEntityNotFoundException)
+            {
+                throw new MongodmEntityNotFoundException($"Can't find key {id}");
+            }
+        }
+
         // Internals.
         async Task INewReferredModelsCreator.CreateNewReferredModelAsync(IEntityModel model, CancellationToken cancellationToken)
         {
@@ -1349,6 +1399,24 @@ namespace Etherna.MongODM.Core.Repositories
             return newModelsCollector.Models;
         }
 
+        private Task<TModel> FindOneOnDBAsync(
+            FilterDefinition<TModel> filter,
+            CancellationToken cancellationToken = default) =>
+            AccessToCollectionAsync(async collection =>
+            {
+                ArgumentNullException.ThrowIfNull(filter);
+
+                using var cursor = await collection.FindAsync(filter, cancellationToken: cancellationToken).ConfigureAwait(false);
+                var model = await cursor.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+                if (model == null)
+                    throw new MongodmEntityNotFoundException("Can't find element");
+
+                logger.RepositoryFoundDocument(Name, DbContext.Engine.Options.DbName, model.Id!.ToString()!);
+
+                return model;
+            });
+
         private static void RefreshModel(IProxyModelsDbContext dbContext, TModel model, TModel updatedModel)
         {
             /* Suppress change tracking on the refresh: the copied members are the just persisted
@@ -1361,6 +1429,68 @@ namespace Etherna.MongODM.Core.Repositories
                     ReflectionHelper.SetValue(model, member, value);
                 }
             }
+        }
+
+        private async Task ReplaceHelperAsync(
+            TModel model,
+            IClientSessionHandle? session,
+            bool updateDependentDocuments,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(model);
+
+            // Auto create the new referred models, before the replace serializes the references.
+            await CreateNewReferredModelsAsync(DiscoverNewReferredModels(model), [model], cancellationToken).ConfigureAwait(false);
+
+            await AccessToCollectionAsync(async collection =>
+            {
+                // Replace on db.
+                var idFilter = new EntityIdEqFilterDefinition<TModel, TKey>(model.Id);
+                ReplaceOneResult result;
+                if (session == null)
+                {
+                    result = await collection.ReplaceOneAsync(
+                        idFilter,
+                        model,
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    result = await collection.ReplaceOneAsync(
+                        session,
+                        idFilter,
+                        model,
+                        cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+
+                // Update dependent documents.
+                /* Skip when the replace matched no document: the model has been deleted
+                 * concurrently, like by a bulk delete with filter, and a dependencies
+                 * update task would fail reloading it. A whole document replace can change any
+                 * member, so all the reference members propagate to their dependent summaries. */
+                if (updateDependentDocuments)
+                {
+                    if (result.MatchedCount > 0)
+                    {
+                        var activeSchema = DbContext.Engine.MapRegistry.GetModelMap(
+                            DbContext.Engine.ProxyGenerator.PurgeProxyType(model.GetType())).ActiveSchema;
+                        DbContext.Engine.DbMaintainer.OnUpdatedModel<TKey>(
+                            model, activeSchema.AllMemberMaps.Select(mm => mm.MemberInfo), this);
+                    }
+                    else
+                        logger.RepositorySkippedDependenciesUpdate(Name, DbContext.Engine.Options.DbName, model.Id!.ToString()!);
+                }
+
+                // Refresh the change tracking: the replaced document is now the model state.
+                if (TrySerializeModelBsonDocument(model) is { } newModelDocument)
+                {
+                    InternalDbContext.SetModelBsonDocument(model, newModelDocument);
+                    InternalDbContext.SetModelSourceRepository(model, this);
+                }
+                InternalDbContext.ClearChangeCandidate(model);
+
+                logger.RepositoryReplacedDocument(Name, DbContext.Engine.Options.DbName, model.Id!.ToString()!);
+            }).ConfigureAwait(false);
         }
 
         private static async Task ScanMissingOriginIdsAsync(
@@ -1470,137 +1600,6 @@ namespace Etherna.MongODM.Core.Repositories
             //reading the model members to serialize must not flag it a change candidate.
             using (InternalDbContext.SuppressChangeTracking())
                 return serializer.SerializeToBsonValue(model).AsBsonDocument;
-        }
-
-        // Protected virtual methods.
-        protected virtual Task CreateOnDBAsync(IEnumerable<TModel> models, CancellationToken cancellationToken) =>
-            AccessToCollectionAsync(collection =>
-            {
-                foreach (var model in models)
-                    ThrowIfIdIsNotAddressable(model);
-
-                return collection.InsertManyAsync(models, null, cancellationToken);
-            });
-
-        protected virtual Task CreateOnDBAsync(TModel model, CancellationToken cancellationToken) =>
-            AccessToCollectionAsync(collection =>
-            {
-                ThrowIfIdIsNotAddressable(model);
-
-                return collection.InsertOneAsync(model, null, cancellationToken);
-            });
-
-        protected virtual Task DeleteOnDBAsync(
-            TModel model,
-            FilterDefinition<TModel>[] additionalFilters,
-            CancellationToken cancellationToken) =>
-            AccessToCollectionAsync(collection =>
-            {
-                ArgumentNullException.ThrowIfNull(model);
-
-                var idFilter = new EntityIdEqFilterDefinition<TModel, TKey>(model.Id);
-
-                return collection.DeleteOneAsync(
-                    additionalFilters.Length == 0 ?
-                        idFilter :
-                        Builders<TModel>.Filter.And(additionalFilters.Prepend(idFilter)),
-                    cancellationToken);
-            });
-
-        protected virtual async Task<TModel> FindOneOnDBAsync(TKey id, CancellationToken cancellationToken = default)
-        {
-            if (id == null)
-                throw new ArgumentNullException(nameof(id));
-
-            try
-            {
-                return await FindOneOnDBAsync(new EntityIdEqFilterDefinition<TModel, TKey>(id), cancellationToken).ConfigureAwait(false);
-            }
-            catch (MongodmEntityNotFoundException)
-            {
-                throw new MongodmEntityNotFoundException($"Can't find key {id}");
-            }
-        }
-
-        // Helpers.
-        private Task<TModel> FindOneOnDBAsync(
-            FilterDefinition<TModel> filter,
-            CancellationToken cancellationToken = default) =>
-            AccessToCollectionAsync(async collection =>
-            {
-                ArgumentNullException.ThrowIfNull(filter);
-
-                using var cursor = await collection.FindAsync(filter, cancellationToken: cancellationToken).ConfigureAwait(false);
-                var model = await cursor.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
-
-                if (model == null)
-                    throw new MongodmEntityNotFoundException("Can't find element");
-
-                logger.RepositoryFoundDocument(Name, DbContext.Engine.Options.DbName, model.Id!.ToString()!);
-
-                return model;
-            });
-
-        private async Task ReplaceHelperAsync(
-            TModel model,
-            IClientSessionHandle? session,
-            bool updateDependentDocuments,
-            CancellationToken cancellationToken)
-        {
-            ArgumentNullException.ThrowIfNull(model);
-
-            // Auto create the new referred models, before the replace serializes the references.
-            await CreateNewReferredModelsAsync(DiscoverNewReferredModels(model), [model], cancellationToken).ConfigureAwait(false);
-
-            await AccessToCollectionAsync(async collection =>
-            {
-                // Replace on db.
-                var idFilter = new EntityIdEqFilterDefinition<TModel, TKey>(model.Id);
-                ReplaceOneResult result;
-                if (session == null)
-                {
-                    result = await collection.ReplaceOneAsync(
-                        idFilter,
-                        model,
-                        cancellationToken: cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
-                    result = await collection.ReplaceOneAsync(
-                        session,
-                        idFilter,
-                        model,
-                        cancellationToken: cancellationToken).ConfigureAwait(false);
-                }
-
-                // Update dependent documents.
-                /* Skip when the replace matched no document: the model has been deleted
-                 * concurrently, like by a bulk delete with filter, and a dependencies
-                 * update task would fail reloading it. A whole document replace can change any
-                 * member, so all the reference members propagate to their dependent summaries. */
-                if (updateDependentDocuments)
-                {
-                    if (result.MatchedCount > 0)
-                    {
-                        var activeSchema = DbContext.Engine.MapRegistry.GetModelMap(
-                            DbContext.Engine.ProxyGenerator.PurgeProxyType(model.GetType())).ActiveSchema;
-                        DbContext.Engine.DbMaintainer.OnUpdatedModel<TKey>(
-                            model, activeSchema.AllMemberMaps.Select(mm => mm.MemberInfo), this);
-                    }
-                    else
-                        logger.RepositorySkippedDependenciesUpdate(Name, DbContext.Engine.Options.DbName, model.Id!.ToString()!);
-                }
-
-                // Refresh the change tracking: the replaced document is now the model state.
-                if (TrySerializeModelBsonDocument(model) is { } newModelDocument)
-                {
-                    InternalDbContext.SetModelBsonDocument(model, newModelDocument);
-                    InternalDbContext.SetModelSourceRepository(model, this);
-                }
-                InternalDbContext.ClearChangeCandidate(model);
-
-                logger.RepositoryReplacedDocument(Name, DbContext.Engine.Options.DbName, model.Id!.ToString()!);
-            }).ConfigureAwait(false);
         }
 
         // Nested types.

--- a/src/MongODM.Core/Serialization/Mapping/MapRegistry.cs
+++ b/src/MongODM.Core/Serialization/Mapping/MapRegistry.cs
@@ -684,26 +684,9 @@ namespace Etherna.MongODM.Core.Serialization.Mapping
                             }
 
                             //descend containers to their serialized items
-                            /* Some serializers implement the container interfaces also when they
-                             * are not able to provide the required information: try with the
-                             * dictionary value first, then with the array item. */
-                            if (serializer is IBsonDictionarySerializer dictionarySerializer)
-                            {
-                                try
-                                {
-                                    serializer = dictionarySerializer.ValueSerializer;
-                                    continue;
-                                }
-                                catch { }
-                            }
-                            if (serializer is IBsonArraySerializer arraySerializer &&
-                                arraySerializer.TryGetItemSerializationInfo(out var itemSerializationInfo))
-                            {
-                                serializer = itemSerializationInfo.Serializer;
-                                continue;
-                            }
-
-                            break;
+                            if (!serializer.TryGetContainerChildSerializer(out var childSerializer))
+                                break;
+                            serializer = childSerializer;
                         }
                     }
                 }

--- a/src/MongODM.Core/Tasks/UpdateDocDependenciesTask.cs
+++ b/src/MongODM.Core/Tasks/UpdateDocDependenciesTask.cs
@@ -149,29 +149,14 @@ namespace Etherna.MongODM.Core.Tasks
                          * unwrapping array and dictionary serializers on collection members: the
                          * same serializer writing the summary at document save, so the refreshed
                          * sub-document keeps the reference schema shape, its schema id, and the
-                         * discriminator of the current referenced model type. Dictionaries
-                         * unwrap first, to their value serializer: their array unwrap stops on
-                         * the key value pair serializer, which hosts no sub-document. */
+                         * discriminator of the current referenced model type. Serializers
+                         * reporting themselves as their own item serializer close the walk,
+                         * instead of unwrapping containers without end. */
                         var documentSerializer = idmm.ParentMemberMap!.Serializer;
-                        while (true)
-                        {
-                            if (documentSerializer is IBsonDictionarySerializer dictionarySerializer)
-                            {
-                                try
-                                {
-                                    documentSerializer = dictionarySerializer.ValueSerializer;
-                                    continue;
-                                }
-                                catch { }
-                            }
-                            if (documentSerializer is IBsonArraySerializer arraySerializer &&
-                                arraySerializer.TryGetItemSerializationInfo(out var itemSerializationInfo))
-                            {
-                                documentSerializer = itemSerializationInfo.Serializer;
-                                continue;
-                            }
-                            break;
-                        }
+                        HashSet<IBsonSerializer> exploredSerializers = [];
+                        while (exploredSerializers.Add(documentSerializer) &&
+                               documentSerializer.TryGetContainerChildSerializer(out var childSerializer))
+                            documentSerializer = childSerializer;
 
                         //use cache
                         if (!serializedDocumentsCache.TryGetValue(documentSerializer, out BsonDocument? doc))


### PR DESCRIPTION
Closes [MODM-266](https://etherna.atlassian.net/browse/MODM-266).

Three small, independent cleanups in `src/MongODM.Core`.

## Inline `DbContext.TryGetRepositoryForModelType`

A one-expression pass-through with a single caller (`TryGetSourceRepository`), inlined per the
no-single-call-site-helper rule.

## Unify the container unwrap step

The step "try the dictionary `ValueSerializer` in a catch, else take the array item serializer" was
copied at three sites with the same empty catch and the same explanatory comment paraphrased:
`Extensions/MemberMapExtensions.cs`, the tail of `MapRegistry.ValidateEntityModelMembers` and
`Tasks/UpdateDocDependenciesTask.cs`.

One `TryGetContainerChildSerializer` extension serves the three loops, writing once why the
dictionary is tried first: the array unwrap of a dictionary would stop on its key value pair
serializer, which wraps no value. Each loop keeps its own termination and accumulation logic — they
are not the same loop: one looks for a reference serializer, one validates entity models, one
descends to the sub-document serializer. `MemberMap.InternalElementPath` stays out, as the issue
asked: its dictionary case also records path representations.

The unwrap loop of the dependencies update task had no cycle guard, so a self referential serializer
would have unwrapped without end — the defect MODM-254 closed on the element path walk. Unreachable
there too (a reference member serializer is never a `BsonValue` one), and closed anyway: all four
serializer walks of the core are guarded now.

## Merge the two `// Helpers.` sections of `Repository.cs`

The file carried two `Helpers` sections, split by the protected virtual methods: the canonical member
ordering is restored — `Public methods`, `Protected virtual methods`, `Internals`, one alphabetically
ordered `Helpers`, `Nested types` — with `FindOneOnDBAsync` and `ReplaceHelperAsync` back in their
alphabetical place. It is the large hunk of this diff, and it is pure movement: no body line changes.

## Tests

None added. The three cleanups are semantics preserving, and the paths they touch — source repository
resolution, serializer exploration at freeze, dependencies propagation — are already densely covered.

## Verification

Full solution build in Release, 0 warnings on net8.0, net9.0 and net10.0. Full test suite green:
351 core unit tests, 5 generator, 86 dashboard, 189 integration against a real MongoDB.

[MODM-266]: https://etherna.atlassian.net/browse/MODM-266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ