### PR TITLE
Remove the AddDbContext overloads registering a fixed db context instance

### DIFF
--- a/src/MongODM.AspNetCore/IMongODMConfiguration.cs
+++ b/src/MongODM.AspNetCore/IMongODMConfiguration.cs
@@ -28,11 +28,6 @@ namespace Etherna.MongODM.AspNetCore
             where TDbContext : DbContext, new();
 
         IMongODMConfiguration AddDbContext<TDbContext>(
-            TDbContext dbContext,
-            Action<DbContextOptions>? dbContextOptionsConfig = null)
-            where TDbContext : DbContext;
-
-        IMongODMConfiguration AddDbContext<TDbContext>(
             Func<IServiceProvider, TDbContext> dbContextCreator,
             Action<DbContextOptions>? dbContextOptionsConfig = null)
             where TDbContext : DbContext;
@@ -41,12 +36,6 @@ namespace Etherna.MongODM.AspNetCore
             Action<DbContextOptions>? dbContextOptionsConfig = null)
             where TDbContext : class, IDbContext
             where TDbContextImpl : DbContext, TDbContext, new();
-
-        IMongODMConfiguration AddDbContext<TDbContext, TDbContextImpl>(
-            TDbContextImpl dbContext,
-            Action<DbContextOptions>? dbContextOptionsConfig = null)
-            where TDbContext : class, IDbContext
-            where TDbContextImpl : DbContext, TDbContext;
 
         IMongODMConfiguration AddDbContext<TDbContext, TDbContextImpl>(
             Func<IServiceProvider, TDbContextImpl> dbContextCreator,

--- a/src/MongODM.AspNetCore/MongODMConfiguration.cs
+++ b/src/MongODM.AspNetCore/MongODMConfiguration.cs
@@ -64,12 +64,6 @@ namespace Etherna.MongODM.AspNetCore
             AddDbContext<TDbContext, TDbContext>(dbContextOptionsConfig);
 
         public IMongODMConfiguration AddDbContext<TDbContext>(
-            TDbContext dbContext,
-            Action<DbContextOptions>? dbContextOptionsConfig = null)
-            where TDbContext : DbContext =>
-            AddDbContext<TDbContext, TDbContext>(_ => dbContext, dbContextOptionsConfig);
-
-        public IMongODMConfiguration AddDbContext<TDbContext>(
             Func<IServiceProvider, TDbContext> dbContextCreator,
             Action<DbContextOptions>? dbContextOptionsConfig = null)
             where TDbContext : DbContext =>
@@ -82,13 +76,6 @@ namespace Etherna.MongODM.AspNetCore
             AddDbContext<TDbContext, TDbContextImpl>(
                 _ => Activator.CreateInstance<TDbContextImpl>(),
                 dbContextOptionsConfig);
-
-        public IMongODMConfiguration AddDbContext<TDbContext, TDbContextImpl>(
-            TDbContextImpl dbContext,
-            Action<DbContextOptions>? dbContextOptionsConfig = null)
-            where TDbContext : class, IDbContext
-            where TDbContextImpl : DbContext, TDbContext =>
-            AddDbContext<TDbContext, TDbContextImpl>(_ => dbContext, dbContextOptionsConfig);
 
         public IMongODMConfiguration AddDbContext<TDbContext, TDbContextImpl>(
             Func<IServiceProvider, TDbContextImpl> dbContextCreator,


### PR DESCRIPTION
Closes [MODM-267](https://etherna.atlassian.net/browse/MODM-267).

## What the issue asked

The `AddDbContext` overloads taking a `TDbContext` / `TDbContextImpl` **instance** registered the
fixed instance as the scoped factory (`_ => dbContext`). Under the scoped-context model this cannot
work beyond the first DI scope: the second scope resolving the db context calls `AttachToEngine` on
the already-attached instance and fails on its guard — whose message literally says "Register db
contexts with a factory to create an instance for each scope".

They are degenerate variants serving a configuration that cannot occur in any multi-request
application, and no call site in src, tests or samples used them.

## The change

Both overloads deleted, from the interface and the implementation. The symmetric forms stay: default
construction (`new()`) and the `Func<IServiceProvider, T>` creator, each in its variant with and
without the service interface.

Removing them is a public API break, so it belongs to 0.25.0, before the overloads publish with the
first supported release.

Related: MODM-102 (1.0.0) rethinks the creator resolution through `IServiceProvider`; this removal is
independent of it.

## Wiki

No sweep needed: `Startup-and-configuration` documents exactly the two forms that stay — without the
service interface, and with the factory — and never mentions the instance overloads.

## Tests

None added. A test asserting an overload does not exist would be a reflection test over the API
surface shape; here compilation is the pin, and the whole solution — four test suites and the sample
included — builds untouched.

## Verification

Full solution build in Release, 0 warnings on net8.0, net9.0 and net10.0. Full test suite green:
351 core unit tests, 5 generator, 86 dashboard, 189 integration against a real MongoDB.

[MODM-267]: https://etherna.atlassian.net/browse/MODM-267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ