### PR TITLE
Simplify the configuration locking and dispose machinery

### DIFF
--- a/src/MongODM.AspNetCore/MongODMConfiguration.cs
+++ b/src/MongODM.AspNetCore/MongODMConfiguration.cs
@@ -24,35 +24,15 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 
 namespace Etherna.MongODM.AspNetCore
 {
     public class MongODMConfiguration(IServiceCollection services)
-        : IMongODMConfiguration, IDisposable
+        : IMongODMConfiguration
     {
         // Fields.
-        private readonly ReaderWriterLockSlim configLock = new(LockRecursionPolicy.SupportsRecursion);
+        private readonly object configLock = new();
         private readonly List<Type> dbContextTypes = new();
-        private bool disposed;
-
-        // Dispose.
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposed) return;
-
-            // Dispose managed resources.
-            if (disposing)
-                configLock.Dispose();
-
-            disposed = true;
-        }
 
         // Properties.
         public bool IsFrozen { get; private set; }
@@ -83,8 +63,7 @@ namespace Etherna.MongODM.AspNetCore
             where TDbContext : class, IDbContext
             where TDbContextImpl : DbContext, TDbContext
         {
-            configLock.EnterWriteLock();
-            try
+            lock (configLock)
             {
                 if (IsFrozen)
                     throw new InvalidOperationException("Configuration is frozen");
@@ -142,38 +121,21 @@ namespace Etherna.MongODM.AspNetCore
 
                 return this;
             }
-            finally
-            {
-                configLock.ExitWriteLock();
-            }
         }
 
         public void Freeze(IMongODMOptionsBuilder mongODMOptionsBuilder)
         {
             ArgumentNullException.ThrowIfNull(mongODMOptionsBuilder);
 
-            configLock.EnterReadLock();
-            try
+            lock (configLock)
             {
                 if (IsFrozen) return;
-            }
-            finally
-            {
-                configLock.ExitReadLock();
-            }
 
-            configLock.EnterWriteLock();
-            try
-            {
                 // Freeze.
                 IsFrozen = true;
 
                 // Report configuration to options.
                 mongODMOptionsBuilder.SetDbContextTypes(dbContextTypes);
-            }
-            finally
-            {
-                configLock.ExitWriteLock();
             }
         }
     }


### PR DESCRIPTION
Closes [MODM-268](https://etherna.atlassian.net/browse/MODM-268).

## What the issue asked

`MongODMConfiguration` is a startup-only builder — constructed inside `AddMongODM`, fed by the
`AddDbContext` calls, frozen once by the `PostConfigure` of the options — that carried machinery
sized for a long-lived concurrent component:

- a `ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion)` guarding code with no recursive
  entry: the delegating `AddDbContext` overloads don't lock, only the master overload and `Freeze`
  do, and they never nest;
- a two phase `Freeze` — read-lock pre-check, then write-lock phase — though it is invoked exactly
  once;
- the full `IDisposable` pattern (`Dispose`/`Dispose(bool)`/`disposed` flag) existing solely to
  dispose that lock, which nothing in the repo ever disposes: the configuration is a local of
  `AddMongODM`, returned to the caller and never registered in the container.

## The change

A plain `private readonly object` with `lock` blocks in the master `AddDbContext` and in `Freeze`
(single phase: `if (IsFrozen) return;` inside the lock), and `IDisposable` dropped entirely. Same
thread safety — mutual exclusion was the only property in use, there being no concurrent readers to
let through in parallel. 38 fewer lines.

`object` rather than the `System.Threading.Lock` type AGENTS prefers: that type is .NET 9+, and
`src/` compiles against net8.0 too under the lowest-target rule. It becomes `Lock` when net8.0 is
dropped.

Breaking on the class surface, not on the interface: `IMongODMConfiguration` does not declare
`IDisposable`, so the removal only touches `MongODMConfiguration` — consumers going through the
interface, the documented way, are unaffected. It belongs to 0.25.0, before the API publishes.

## Tests

None added. No suite can tell a `lock` from a write lock, and the paths involved — db context
registration, freeze, and the refusal after freeze — are already exercised by every integration test,
each of which builds the whole configuration at startup.

## Verification

Full solution build in Release, 0 warnings on net8.0, net9.0 and net10.0. Full test suite green:
351 core unit tests, 5 generator, 86 dashboard, 189 integration against a real MongoDB.

[MODM-268]: https://etherna.atlassian.net/browse/MODM-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ