### PR TITLE
Simplify the proxy models generator symbol inspection

### DIFF
--- a/src/MongODM.Core.Generators/ProxyModelsGenerator.cs
+++ b/src/MongODM.Core.Generators/ProxyModelsGenerator.cs
@@ -95,13 +95,16 @@ namespace Etherna.MongODM.Core.Generators
         private static ProxyModelInfo BuildProxyModelInfo(INamedTypeSymbol classSymbol, Compilation compilation)
         {
             var methodAnalyzer = new AlteredMembersAnalyzer(classSymbol, compilation);
+            var entityInterface = classSymbol.AllInterfaces
+                .FirstOrDefault(i => i.IsGenericType && i.ConstructedFrom.ToDisplayString() == EntityModelInterfaceFullName + "<TKey>");
+            var keyType = entityInterface?.TypeArguments[0];
             var info = new ProxyModelInfo
             {
                 Accessibility = classSymbol.DeclaredAccessibility == Accessibility.Public ? "public" : "internal",
-                IdPropertyName = FindEntityIdProperty(classSymbol)?.Name ?? "Id",
-                KeyTypeIsNullable = FindEntityKeyType(classSymbol) is { } keyType &&
-                                    (keyType.IsReferenceType || keyType.NullableAnnotation == NullableAnnotation.Annotated ||
-                                     keyType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T),
+                IdPropertyName = FindEntityIdProperty(classSymbol, entityInterface)?.Name ?? "Id",
+                KeyTypeIsNullable = keyType is { IsReferenceType: true } or
+                                               { NullableAnnotation: NullableAnnotation.Annotated } or
+                                               { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T },
                 ModelFullName = classSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                 ModelName = classSymbol.Name,
                 Namespace = classSymbol.ContainingNamespace.IsGlobalNamespace ?
@@ -138,7 +141,7 @@ namespace Etherna.MongODM.Core.Generators
                                 info.WritableProperties.Add(BuildWritablePropertyInfo(property, type, classSymbol));
 
                             //accessible virtual properties get interception overrides
-                            if (IsOverridable(property, property.IsVirtual, property.IsOverride, property.IsSealed, property.DeclaredAccessibility))
+                            if (IsOverridable(property))
                                 info.OverriddenProperties.Add(BuildOverriddenPropertyInfo(property));
                             break;
 
@@ -147,7 +150,7 @@ namespace Etherna.MongODM.Core.Generators
                                 continue;
                             if (method.IsGenericMethod ||
                                 GetOverrideRoot(method).ContainingType.SpecialType == SpecialType.System_Object ||
-                                !IsOverridable(method, method.IsVirtual, method.IsOverride, method.IsSealed, method.DeclaredAccessibility))
+                                !IsOverridable(method))
                                 continue;
 
                             info.OverriddenMethods.Add(BuildOverriddenMethodInfo(method, methodAnalyzer));
@@ -165,13 +168,11 @@ namespace Etherna.MongODM.Core.Generators
             return info;
         }
 
-        private static IPropertySymbol? FindEntityIdProperty(INamedTypeSymbol classSymbol)
+        private static IPropertySymbol? FindEntityIdProperty(INamedTypeSymbol classSymbol, INamedTypeSymbol? entityInterface)
         {
             /* The identity property is the implicit implementation of the typed entity model
              * interface id. Models without it (or with an explicit implementation) fall back
              * to the "Id" name convention, like the lazy load emission does. */
-            var entityInterface = classSymbol.AllInterfaces
-                .FirstOrDefault(i => i.IsGenericType && i.ConstructedFrom.ToDisplayString() == EntityModelInterfaceFullName + "<TKey>");
             if (entityInterface?.GetMembers("Id").OfType<IPropertySymbol>().FirstOrDefault() is { } interfaceIdProperty &&
                 classSymbol.FindImplementationForInterfaceMember(interfaceIdProperty) is IPropertySymbol implementingProperty &&
                 implementingProperty.ExplicitInterfaceImplementations.IsEmpty)
@@ -179,20 +180,12 @@ namespace Etherna.MongODM.Core.Generators
             return null;
         }
 
-        private static ITypeSymbol? FindEntityKeyType(INamedTypeSymbol classSymbol) =>
-            classSymbol.AllInterfaces
-                .FirstOrDefault(i => i.IsGenericType && i.ConstructedFrom.ToDisplayString() == EntityModelInterfaceFullName + "<TKey>")?
-                .TypeArguments[0];
-
-        private static bool IsOverridable(
-            ISymbol member,
-            bool isVirtual,
-            bool isOverride,
-            bool isSealed,
-            Accessibility accessibility) =>
-            (isVirtual || (isOverride && !isSealed)) &&
-            accessibility is Accessibility.Public or Accessibility.Protected or Accessibility.ProtectedOrInternal &&
-            member.ContainingType.SpecialType != SpecialType.System_Object;
+        private static bool IsOverridable(ISymbol member) =>
+            member is
+            {
+                DeclaredAccessibility: Accessibility.Public or Accessibility.Protected or Accessibility.ProtectedOrInternal,
+                ContainingType.SpecialType: not SpecialType.System_Object
+            } and ({ IsVirtual: true } or { IsOverride: true, IsSealed: false });
 
         private static IMethodSymbol GetOverrideRoot(IMethodSymbol method)
         {


### PR DESCRIPTION
Closes [MODM-269](https://etherna.atlassian.net/browse/MODM-269).

## Collapse `IsOverridable` to the symbol it already receives

`IsOverridable` took four parameters (`isVirtual`, `isOverride`, `isSealed`, `accessibility`) that
are all members of the `ISymbol` it already had as first parameter, turning both call sites into
130-character lines. It now reads them off the symbol, as one property pattern:

```csharp
private static bool IsOverridable(ISymbol member) =>
    member is
    {
        DeclaredAccessibility: Accessibility.Public or Accessibility.Protected or Accessibility.ProtectedOrInternal,
        ContainingType.SpecialType: not SpecialType.System_Object
    } and ({ IsVirtual: true } or { IsOverride: true, IsSealed: false });
```

Same semantics: an override carries `IsOverride: true` and `IsVirtual: false` in Roslyn, so the two
alternatives stay disjoint exactly like `(isVirtual || (isOverride && !isSealed))`. The generators
project compiles with `LangVersion latest`, so the extended property patterns are available. The call
sites become `IsOverridable(property)` and `IsOverridable(method)`.

## Resolve the entity interface once

`FindEntityIdProperty` and `FindEntityKeyType`, each called once from `BuildProxyModelInfo`, walked
the same `AllInterfaces` looking for the same `IEntityModel<TKey>`. The interface now resolves once in
`BuildProxyModelInfo`: `FindEntityKeyType` goes (the key type is `entityInterface?.TypeArguments[0]`,
inline) and `FindEntityIdProperty` receives the resolved interface.

The nullability test that consumed it is rewritten as a property pattern too; a null key type
satisfies none of its alternatives and yields `false`, like the leading `is { }` did.

Zero behavior change.

## Tests

None added, and the existing coverage is the strongest of this series: the generator suite pins the
selection rules, the emitted shape and the compile check of the generated sources, and every project
of the repo defining models — core, tests, sample — generates its own proxies at each build, with the
189 integration tests running entirely on proxy instances. A semantic change in `IsOverridable` would
change which members are intercepted and break change tracking outright.

## Verification

Full solution build in Release, 0 warnings on net8.0, net9.0 and net10.0. Full test suite green:
5 generator tests, 351 core unit tests, 86 dashboard, 189 integration against a real MongoDB.

[MODM-269]: https://etherna.atlassian.net/browse/MODM-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ