### PR TITLE
Minor cleanups across the aspnetcore, ui, hangfire and meta packages

### DIFF
--- a/src/MongODM.AspNetCore.UI/Areas/MongODM/Pages/Index.cshtml.cs
+++ b/src/MongODM.AspNetCore.UI/Areas/MongODM/Pages/Index.cshtml.cs
@@ -109,14 +109,11 @@ namespace Etherna.MongODM.AspNetCore.UI.Areas.MongODM.Pages
         {
             ArgumentNullException.ThrowIfNull(repository);
 
-            return repository.DbContext.Engine.MapRegistry.MapsByModelType.Values
-                .OfType<IModelMap>()
-                .Where(map => !map.ModelType.IsAbstract &&
-                    repository.ModelType.IsAssignableFrom(map.ModelType))
-                .OrderBy(map => map.ModelType.Name)
-                .SelectMany(map => map.SecondarySchemas
-                    .Select(schema => (ModelTypeName: map.ModelType.Name, SchemaId: schema.Id, IsActiveSchema: false))
-                    .Prepend((ModelTypeName: map.ModelType.Name, SchemaId: map.ActiveSchema.Id, IsActiveSchema: true)));
+            return GetStorableSchemas(repository.ModelType, repository.DbContext.Engine.MapRegistry)
+                .Select(storable => (
+                    ModelTypeName: storable.Map.ModelType.Name,
+                    SchemaId: storable.Schema.Id,
+                    storable.IsActiveSchema));
         }
 
         public void OnGet()
@@ -642,18 +639,30 @@ namespace Etherna.MongODM.AspNetCore.UI.Areas.MongODM.Pages
             IMapRegistry mapRegistry,
             IRepository[] repositories,
             HashSet<IModelMapSchema> exploringSchemas) =>
-            mapRegistry.MapsByModelType.Values
-                .OfType<IModelMap>()
-                .Where(map => !map.ModelType.IsAbstract && modelType.IsAssignableFrom(map.ModelType))
-                .OrderBy(map => map.ModelType.Name, StringComparer.Ordinal)
-                .SelectMany(map => map.SecondarySchemas.Prepend(map.ActiveSchema))
-                .Select(schema => BuildDocumentShape(
-                    schema.ModelMap.DefinedMemberMaps.Where(memberMap => memberMap.ModelMapSchema == schema),
-                    schema,
+            GetStorableSchemas(modelType, mapRegistry)
+                .Select(storable => BuildDocumentShape(
+                    storable.Schema.ModelMap.DefinedMemberMaps.Where(
+                        memberMap => memberMap.ModelMapSchema == storable.Schema),
+                    storable.Schema,
                     mapRegistry,
                     repositories,
                     exploringSchemas))
                 .ToArray();
+
+        /* The model map schemas a document stored where the model type is declared can carry:
+         * those of the concrete model types assignable to it, active schema first, since a
+         * document carries the active schema id of its own concrete type. Fallback schemas
+         * stay out, their reserved id is never written. */
+        private static IEnumerable<(IModelMap Map, IModelMapSchema Schema, bool IsActiveSchema)> GetStorableSchemas(
+            Type modelType,
+            IMapRegistry mapRegistry) =>
+            mapRegistry.MapsByModelType.Values
+                .OfType<IModelMap>()
+                .Where(map => !map.ModelType.IsAbstract && modelType.IsAssignableFrom(map.ModelType))
+                .OrderBy(map => map.ModelType.Name, StringComparer.Ordinal)
+                .SelectMany(map => map.SecondarySchemas
+                    .Select(schema => (Map: map, Schema: schema, IsActiveSchema: false))
+                    .Prepend((Map: map, Schema: map.ActiveSchema, IsActiveSchema: true)));
 
         private static string RenderTypeName(Type type) =>
             type.IsGenericType ?

--- a/src/MongODM.AspNetCore.UI/Auth/Handlers/ValidFiltersHandler.cs
+++ b/src/MongODM.AspNetCore.UI/Auth/Handlers/ValidFiltersHandler.cs
@@ -33,21 +33,16 @@ namespace Etherna.MongODM.AspNetCore.UI.Auth.Handlers
              * one denying it. A dashboard configured without filters is unrestricted: an
              * application with no authorization of its own declares it emptying the list,
              * instead of configuring a filter allowing everyone. */
-            var isAuthorized = true;
-
             foreach (var filter in requirement.Filters)
             {
                 if (!await filter.AuthorizeAsync(httpContext).ConfigureAwait(false))
                 {
-                    isAuthorized = false;
-                    break;
+                    context.Fail();
+                    return;
                 }
             }
 
-            if (isAuthorized)
-                context.Succeed(requirement);
-            else
-                context.Fail();
+            context.Succeed(requirement);
         }
     }
 }

--- a/src/MongODM.Hangfire/Filters/AsyncLocalContextHangfireFilter.cs
+++ b/src/MongODM.Hangfire/Filters/AsyncLocalContextHangfireFilter.cs
@@ -24,17 +24,7 @@ namespace Etherna.MongODM.HF.Filters
         // Fields.
         private readonly Dictionary<string, IAsyncLocalContextHandler> contextHandlers = new();
 
-        // Properties.
-        public void OnPerforming(PerformingContext context)
-        {
-            ArgumentNullException.ThrowIfNull(context);
-
-            lock (contextHandlers)
-            {
-                contextHandlers.Add(context.BackgroundJob.Id, asyncLocalContext.InitAsyncLocalContext());
-            }
-        }
-
+        // Methods.
         public void OnPerformed(PerformedContext context)
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -45,6 +35,16 @@ namespace Etherna.MongODM.HF.Filters
                 var contextHandler = contextHandlers[jobId];
                 contextHandlers.Remove(jobId);
                 contextHandler.Dispose();
+            }
+        }
+
+        public void OnPerforming(PerformingContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            lock (contextHandlers)
+            {
+                contextHandlers.Add(context.BackgroundJob.Id, asyncLocalContext.InitAsyncLocalContext());
             }
         }
     }

--- a/src/MongODM/Extensions/ServiceCollectionExtensions.cs
+++ b/src/MongODM/Extensions/ServiceCollectionExtensions.cs
@@ -36,26 +36,16 @@ namespace Etherna.MongODM.Extensions
             var conf = services.AddMongODM<HangfireTaskRunner>(configureMongODMOptions);
 
             // Configure Hangfire.
-            AddHangfire(services, configureHangfireOptions);
-
-            return conf;
-        }
-
-        // Helpers.
-        private static void AddHangfire(
-            IServiceCollection services,
-            Action<HangfireOptions>? configureHangfireOptions)
-        {
-            // Configure options.
             var hangfireOptions = new HangfireOptions();
             configureHangfireOptions?.Invoke(hangfireOptions);
 
-            // Add hangfire.
             services.AddHangfire(options =>
             {
                 options.UseMongODM();
                 options.UseMongoStorage(hangfireOptions.ConnectionString, hangfireOptions.StorageOptions);
             });
+
+            return conf;
         }
     }
 }

--- a/src/MongODM/HangfireOptions.cs
+++ b/src/MongODM/HangfireOptions.cs
@@ -20,20 +20,14 @@ namespace Etherna.MongODM
 {
     public class HangfireOptions
     {
-        public HangfireOptions()
+        public string ConnectionString { get; set; } = "mongodb://localhost/hangfire";
+        public MongoStorageOptions StorageOptions { get; set; } = new()
         {
-            ConnectionString = "mongodb://localhost/hangfire";
-            StorageOptions = new MongoStorageOptions
+            MigrationOptions = new MongoMigrationOptions
             {
-                MigrationOptions = new MongoMigrationOptions
-                {
-                    MigrationStrategy = new MigrateMongoMigrationStrategy(),
-                    BackupStrategy = new CollectionMongoBackupStrategy()
-                }
-            };
-        }
-
-        public string ConnectionString { get; set; }
-        public MongoStorageOptions StorageOptions { get; set; }
+                MigrationStrategy = new MigrateMongoMigrationStrategy(),
+                BackupStrategy = new CollectionMongoBackupStrategy()
+            }
+        };
     }
 }


### PR DESCRIPTION
Closes [MODM-271](https://etherna.atlassian.net/browse/MODM-271).

Five small, independent cleanups outside the core package.

## `ValidFiltersHandler`: early return instead of flag-and-break

The loop kept an `isAuthorized` mutable only to decide, after it, which of the two calls to make. It
now fails and returns on the first denying filter, and succeeds after the loop: identical semantics,
one less mutable.

## `Index.cshtml.cs`: one shared storable schemas enumeration, settled on Ordinal

The enumeration — concrete model maps assignable to the repository model type, active schema first —
was duplicated between `GetDocumentSchemas` and `ExploreModelMapShapes` **with different comparers**:
the first ordered with the culture-sensitive `OrderBy(map => map.ModelType.Name)`, the second with
`StringComparer.Ordinal`. Two sections of the same page could therefore list the same types in a
different order, depending on the culture of the process.

One private `GetStorableSchemas` helper now yields the `(Map, Schema, IsActiveSchema)` triples both
derive their own projection from, settled on Ordinal. The observable change is the ordering of the
dashboard model schemas section, which becomes the deterministic one the document structures already
used.

## `HangfireOptions`: property initializers

The constructor only assigned defaults; they are initializers now, with a target-typed `new()` for
the storage options.

## Meta package `ServiceCollectionExtensions`: inline the single-use `AddHangfire`

Inlined per the no-single-call-site-helper rule, with the two comment headings that restated the
lines under them dropped — the `// Configure Hangfire.` above covers both.

## `AsyncLocalContextHangfireFilter`: section label, and alphabetical order

The `// Properties.` label sat over two methods: it reads `// Methods.` now, and `OnPerformed`
precedes `OnPerforming` per the alphabetical ordering rule.

## Tests

None added. The first four are semantics preserving. The comparer change is an ordering observable
only with two type names that sort differently across cultures: the 86 dashboard tests, which render
the schemas section over a real map registry, stay green, and a test built to tell Ordinal from
culture-sensitive would pin a comparer choice rather than behavior that could silently regress.

## Verification

Full solution build in Release, 0 warnings on net8.0, net9.0 and net10.0. Full test suite green:
351 core unit tests, 5 generator, 86 dashboard, 189 integration against a real MongoDB.

[MODM-271]: https://etherna.atlassian.net/browse/MODM-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ