### PR TITLE
Unify the lease construction guard of the resource lock

### DIFF
--- a/src/MongODM.Core/Utility/ResourceLock.cs
+++ b/src/MongODM.Core/Utility/ResourceLock.cs
@@ -222,19 +222,29 @@ namespace Etherna.MongODM.Core.Utility
             if (leaseDuration is null)
                 return null;
 
+            return await CreateLeaseReleasingOnFailureAsync(
+                ownerId, leaseId, leaseDuration.Value, ResourceLockMode.Exclusive).ConfigureAwait(false);
+        }
+
+        // Helpers.
+        private async Task<IResourceLockLease> CreateLeaseReleasingOnFailureAsync(
+            string ownerId,
+            string leaseId,
+            TimeSpan leaseDuration,
+            ResourceLockMode mode)
+        {
             try
             {
-                return new ResourceLockLease(this, ownerId, leaseId, leaseDuration.Value, ResourceLockMode.Exclusive);
+                return new ResourceLockLease(this, ownerId, leaseId, leaseDuration, mode);
             }
             catch
             {
-                //the stamp already extended the lease: without an owning lease nobody would release it
-                await ReleaseExclusiveLockAsync(OwnedLeaseFilter(ownerId, leaseId)).ConfigureAwait(false);
+                //the claim already holds the lock: without an owning lease nobody would release it
+                await ReleaseLeaseAsync(ownerId, leaseId, mode).ConfigureAwait(false);
                 throw;
             }
         }
 
-        // Helpers.
         private async Task<bool> HasLiveExclusiveLeaseAsync() =>
             await lockCollection.CountDocumentsAsync(
                 Builders<BsonDocument>.Filter.And(
@@ -255,6 +265,11 @@ namespace Etherna.MongODM.Core.Utility
                 Builders<BsonDocument>.Filter.And(
                     Builders<BsonDocument>.Filter.Eq("_id", lockId),
                     ownershipFilter));
+
+        private Task ReleaseLeaseAsync(string ownerId, string leaseId, ResourceLockMode mode) =>
+            mode is ResourceLockMode.Shared ?
+                ReleaseSharedLeaseAsync(leaseId) :
+                ReleaseExclusiveLockAsync(OwnedLeaseFilter(ownerId, leaseId));
 
         private async Task ReleaseSharedLeaseAsync(string leaseId)
         {
@@ -324,16 +339,8 @@ namespace Etherna.MongODM.Core.Utility
             if (!await TryClaimExclusiveAsync(ownerId, acquiredLeaseDuration, leaseId).ConfigureAwait(false))
                 return null;
 
-            try
-            {
-                return new ResourceLockLease(this, ownerId, leaseId, acquiredLeaseDuration, ResourceLockMode.Exclusive);
-            }
-            catch
-            {
-                //the claim already holds the lock: without an owning lease nobody would release it
-                await ReleaseExclusiveLockAsync(OwnedLeaseFilter(ownerId, leaseId)).ConfigureAwait(false);
-                throw;
-            }
+            return await CreateLeaseReleasingOnFailureAsync(
+                ownerId, leaseId, acquiredLeaseDuration, ResourceLockMode.Exclusive).ConfigureAwait(false);
         }
 
         private async Task<IResourceLockLease?> TryAcquireSharedAsync(TimeSpan? leaseDuration)
@@ -358,16 +365,8 @@ namespace Etherna.MongODM.Core.Utility
                     return null;
             }
 
-            try
-            {
-                return new ResourceLockLease(this, ownerId, leaseId, acquiredLeaseDuration, ResourceLockMode.Shared);
-            }
-            catch
-            {
-                //the claim already holds the lock: without an owning lease nobody would release it
-                await ReleaseSharedLeaseAsync(leaseId).ConfigureAwait(false);
-                throw;
-            }
+            return await CreateLeaseReleasingOnFailureAsync(
+                ownerId, leaseId, acquiredLeaseDuration, ResourceLockMode.Shared).ConfigureAwait(false);
         }
 
         private async Task<bool> TryClaimExclusiveAsync(string ownerId, TimeSpan leaseDuration, string? leaseId)
@@ -661,9 +660,7 @@ namespace Etherna.MongODM.Core.Utility
                 }
             }
 
-            private Task ReleaseAsync() => mode is ResourceLockMode.Shared
-                ? resourceLock.ReleaseSharedLeaseAsync(leaseId)
-                : resourceLock.ReleaseExclusiveLockAsync(OwnedLeaseFilter(OwnerId, leaseId));
+            private Task ReleaseAsync() => resourceLock.ReleaseLeaseAsync(OwnerId, leaseId, mode);
 
             private Task<bool> TryRenewAsync() => mode is ResourceLockMode.Shared
                 ? resourceLock.TryRenewSharedLeaseAsync(leaseId, leaseDuration)


### PR DESCRIPTION
Closes [MODM-272](https://etherna.atlassian.net/browse/MODM-272).

## What the issue asked

The three acquisition variants — `TryResumeClaimAsync`, `TryAcquireExclusiveAsync`,
`TryAcquireSharedAsync` — all closed with the same guard: `try { return new ResourceLockLease(...); }
catch { <release>; throw; }`. If the lease construction fails the claim is already on the server and
nobody would release it, so it has to be undone by hand. Only the release call differed, and that is
exactly the mode branch the lease's own `ReleaseAsync` already encodes.

## The change

`CreateLeaseReleasingOnFailureAsync(ownerId, leaseId, leaseDuration, mode)`, shared by all three: the
step belongs to every variant of the family, so it passes the symmetry rule.

A second helper the issue didn't ask for comes with it: without it the mode-to-release mapping would
have ended up written in two places — inside the new helper and inside `ResourceLockLease.ReleaseAsync`
— trading a three-site repetition for a two-site one and missing the stated goal of single-sourcing
the undo logic. So `ReleaseLeaseAsync(ownerId, leaseId, mode)` holds that mapping, used by the helper
and by the lease, whose `ReleaseAsync` becomes a delegation. It is kept rather than inlined, despite
its single caller, because it sits beside `TryRenewAsync`, which has the same mode-branch shape:
they are a symmetric pair, and dissolving one of them alone would break it.

## The trade

Each `catch` used to tell its own situation — "the stamp already extended the lease" in the resume,
"the claim already holds the lock" in the two acquisitions — and the explicit release call showed at a
glance which claim was being undone. The unification buys single-sourcing and pays with that local
storytelling: the shared comment now reads "the claim already holds the lock" for all three, true for
the resume as well but less precise.

The line count is modest — 3 net lines, the second helper eating most of the 16 the issue estimated.
The real win is that a fourth lock mode would have one place to touch instead of four.

## Tests

None added. `ResourceLockTest` and the integration `ResourceLockTests` already exercise exclusive and
shared acquisition, resume and release; the `catch` branch is unreachable under normal conditions, it
fires only if the lease constructor fails.

## Verification

Full solution build in Release, 0 warnings on net8.0, net9.0 and net10.0. Full test suite green:
351 core unit tests, 5 generator, 86 dashboard, 189 integration against a real MongoDB.

[MODM-272]: https://etherna.atlassian.net/browse/MODM-272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ