### PR TITLE
Build the models out of the proxy generator with their parameterless constructor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,7 @@ Private properties never mix with the public ones either: they go in their own `
 
 - `virtual` on all properties and methods for proxy support
 - Protected parameterless constructor for deserialization
+- Models deserialize through that constructor and their member setters, never through a domain constructor: the schema drops the class map creators the driver maps from the public constructors whose parameters match the members. It keeps them only for a model that has no parameterless constructor, or whose creator feeds a member with no setter, since those can't be built otherwise. On such a model a new constructor parameter makes the documents written before it unreadable, so it needs a new schema id
 - Collection encapsulation with a private backing field exposed as `IEnumerable<T>`, never `null` (at most empty)
 - No manual lazy-load annotations: the proxy models source generator analyzes each domain method body and computes the properties it alters (direct backing field accesses included, following non virtual helpers), triggering the full load when such a method runs on a summary model. A method without analyzable source (compiled cross-assembly bases) conservatively full loads on summaries. Collections stay encapsulated (read-only interface, non public setter), mutated only through domain methods, so a snapshot diff always detects the change
 - Prefer immutable exposure. A getter that hands out mutable state (a `List<T>`/`Dictionary<>`, or a complex value with public setters or business methods) is legal, but **reading it flags the model for a diff at save** — a change could otherwise escape interception. Expose collections read-only and make embedded value objects immutable (records, get/init-only, no mutating methods) to keep reads free; entity references never count (tracked on their own repository). `ProxyModels/MutabilityAnalyzer` computes this; casting a read-only collection back to mutable to bypass it is unsupported
@@ -223,5 +224,6 @@ Private properties never mix with the public ones either: they go in their own `
 - `[Fact]` for basic tests, `[Theory]` with `[InlineData]`/`[MemberData]` for parameterized cases
 - xUnit assertions: `Assert.Equal()`, `Assert.NotNull()`, `Assert.ThrowsAsync<T>()`
 - Moq for mocking: `new Mock<IDbContext>()`
+- Deserialization tests carry one raw source document per version that wrote it, each commented with its schema id and that version, and listed from the newest down: the recent schemas are the ones a reader comes looking for
 - **No `ConfigureAwait` in test code** — inside tests write plain `await foo()`; the library rule applies to `src/` only
 - The test project mirrors the `Scrinium.Core` layout

--- a/src/Scrinium.Core/Serialization/Mapping/ModelMapSchema.cs
+++ b/src/Scrinium.Core/Serialization/Mapping/ModelMapSchema.cs
@@ -111,21 +111,7 @@ namespace Etherna.Scrinium.Core.Serialization.Mapping
                 if (ModelMap.ModelType.IsAbstract)
                     throw new InvalidOperationException("Can't generate proxy of an abstract model");
 
-                // Remove CreatorMaps.
-                while (bsonClassMap.CreatorMaps.Any())
-                {
-                    var memberInfo = bsonClassMap.CreatorMaps.First().MemberInfo;
-                    switch (memberInfo)
-                    {
-                        case ConstructorInfo constructorInfo:
-                            bsonClassMap.UnmapConstructor(constructorInfo);
-                            break;
-                        case MethodInfo methodInfo:
-                            bsonClassMap.UnmapFactoryMethod(methodInfo);
-                            break;
-                        default: throw new InvalidOperationException();
-                    }
-                }
+                RemoveCreatorMaps();
 
                 // Set creator.
                 bsonClassMap.SetCreator(() => dbContextEngine.ProxyGenerator.CreateInstance(ModelMap.ModelType));
@@ -137,8 +123,7 @@ namespace Etherna.Scrinium.Core.Serialization.Mapping
 
             // Verify if can use proxy model.
             /* Only concrete entity models deserialize as proxies: lazy loading and change
-             * candidate marking only apply to them. Any other model keeps its natural
-             * class map creators. */
+             * candidate marking only apply to them. */
             if (ModelMap.ModelType is { IsClass: true, IsAbstract: false } &&
                 typeof(IEntityModel).IsAssignableFrom(ModelMap.ModelType))
             {
@@ -146,6 +131,37 @@ namespace Etherna.Scrinium.Core.Serialization.Mapping
                 return true;
             }
 
+            /* Any other model builds through the parameterless constructor it declares for
+             * deserialization, and its member setters: the driver would otherwise build it
+             * with one of the class map creators it maps from the public constructors, which
+             * runs the domain logic of the constructor on the stored values, and fails the
+             * read of a document written before one of its arguments existed.
+             * The creators stay on a model that can't be built without them: with no
+             * parameterless constructor the driver would build uninitialized instances,
+             * skipping the field initializers, and a member with no setter takes its value
+             * only as a creator argument. */
+            ExecuteConfigAction(() =>
+            {
+                var parameterlessConstructor = ModelMap.ModelType.GetConstructor(
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                    null,
+                    Type.EmptyTypes,
+                    null);
+                if (parameterlessConstructor is null)
+                    return;
+
+                if (bsonClassMap.CreatorMaps
+                    .SelectMany(creatorMap => creatorMap.Arguments)
+                    .Any(argument => argument switch
+                    {
+                        PropertyInfo propertyInfo => !propertyInfo.CanWrite,
+                        FieldInfo fieldInfo => fieldInfo.IsInitOnly,
+                        _ => true
+                    }))
+                    return;
+
+                RemoveCreatorMaps();
+            });
             return false;
         }
 
@@ -168,6 +184,29 @@ namespace Etherna.Scrinium.Core.Serialization.Mapping
 
         // Internal methods.
         internal void AddGeneratedMemberMap(IMemberMap memberMap) => _generatedMemberMaps.Add(memberMap);
+
+        // Helpers.
+        /// <summary>
+        /// Drop the class map creators of the schema, so the models build through their
+        /// parameterless constructor and their member setters.
+        /// </summary>
+        private void RemoveCreatorMaps()
+        {
+            while (bsonClassMap.CreatorMaps.Any())
+            {
+                var memberInfo = bsonClassMap.CreatorMaps.First().MemberInfo;
+                switch (memberInfo)
+                {
+                    case ConstructorInfo constructorInfo:
+                        bsonClassMap.UnmapConstructor(constructorInfo);
+                        break;
+                    case MethodInfo methodInfo:
+                        bsonClassMap.UnmapFactoryMethod(methodInfo);
+                        break;
+                    default: throw new InvalidOperationException();
+                }
+            }
+        }
     }
 
     public class ModelMapSchema<TModel> : ModelMapSchema, IModelMapSchema<TModel>

--- a/test/Scrinium.Core.UnitTests/Domain/ModelMaps/DbMigrationOperationDeserializationTest.cs
+++ b/test/Scrinium.Core.UnitTests/Domain/ModelMaps/DbMigrationOperationDeserializationTest.cs
@@ -1,0 +1,311 @@
+// Copyright 2020-present Etherna SA
+// This file is part of Scrinium.
+// 
+// Scrinium is free software: you can redistribute it and/or modify it under the terms of the
+// GNU Lesser General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// 
+// Scrinium is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License along with Scrinium.
+// If not, see <https://www.gnu.org/licenses/>.
+
+using Etherna.MongoDB.Bson;
+using Etherna.MongoDB.Bson.IO;
+using Etherna.MongoDB.Bson.Serialization;
+using Etherna.MongoDB.Driver;
+using Etherna.Scrinium.Core.Conventions;
+using Etherna.Scrinium.Core.Domain.Models;
+using Etherna.Scrinium.Core.Domain.Models.DbMigrationOpAgg;
+using Etherna.Scrinium.Core.ExecContext.AsyncLocal;
+using Etherna.Scrinium.Core.Models;
+using Etherna.Scrinium.Core.Options;
+using Etherna.Scrinium.Core.ProxyModels;
+using Etherna.Scrinium.Core.Repositories;
+using Etherna.Scrinium.Core.Serialization.Mapping;
+using Etherna.Scrinium.Core.Serialization.Modifiers;
+using Etherna.Scrinium.Core.Serialization.Serializers;
+using Etherna.Scrinium.Core.Utility;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Etherna.Scrinium.Core.Domain.ModelMaps
+{
+    public class DbMigrationOperationDeserializationTest : IDisposable
+    {
+        // Internal classes.
+        public class DeserializationTestElement(string sourceDocument, DbMigrationOperation expectedModel)
+        {
+            public DbMigrationOperation ExpectedModel { get; } = expectedModel;
+            public string SourceDocument { get; } = sourceDocument;
+        }
+
+        // Fields.
+        private readonly FakeDbContext dbContext = new();
+        private readonly IDbContextEngine engine;
+
+        // Constructor.
+        /* Build a real engine over a real map registry: the documents deserialize through the
+         * internal model maps registered by the engine initialization, as they do in an
+         * application reading its own operations collection. */
+        public DbMigrationOperationDeserializationTest()
+        {
+            var dependenciesMock = new Mock<IDbDependencies>();
+            dependenciesMock.Setup(d => d.BsonSerializerRegistry)
+                .Returns(new BsonSerializerRegistry());
+            dependenciesMock.Setup(d => d.DbMaintainer)
+                .Returns(new Mock<IDbMaintainer>().Object);
+            dependenciesMock.Setup(d => d.DbMigrationManager)
+                .Returns(new Mock<IDbMigrationManager>().Object);
+            dependenciesMock.Setup(d => d.DiscriminatorRegistry)
+                .Returns(new DiscriminatorRegistry());
+            dependenciesMock.Setup(d => d.ExecutionContext)
+                .Returns(AsyncLocalContext.Instance);
+            dependenciesMock.Setup(d => d.MapRegistry)
+                .Returns(new MapRegistry());
+            dependenciesMock.Setup(d => d.ProxyGenerator)
+                .Returns(new ProxyGenerator(AsyncLocalContext.Instance));
+            dependenciesMock.Setup(d => d.RepositoryRegistry)
+                .Returns(new RepositoryRegistry());
+            dependenciesMock.Setup(d => d.SerializerModifierAccessor)
+                .Returns(new SerializerModifierAccessor(AsyncLocalContext.Instance));
+
+            /* Register the static integration with the driver, like the service collection
+             * extension of the library does at startup: the driver resolves the discriminator
+             * convention and the serialization context from its own statics while deserializing
+             * the documents nested in an operation. */
+            try
+            {
+                BsonSerializer.RegisterDiscriminatorConvention(typeof(object),
+                    new HierarchicalProxyTolerantDiscriminatorConvention("_t", AsyncLocalContext.Instance));
+            }
+            catch (BsonSerializationException)
+            { }
+            BsonSerializer.SetSerializationContextAccessor(
+                new SerializationContextAccessor(AsyncLocalContext.Instance));
+
+            var mongoClientMock = new Mock<IMongoClient>();
+            mongoClientMock.Setup(c => c.GetDatabase(It.IsAny<string>(), It.IsAny<MongoDatabaseSettings>()))
+                .Returns(new Mock<IMongoDatabase>().Object);
+
+            engine = dbContext.BuildEngine(
+                dependenciesMock.Object,
+                mongoClientMock.Object,
+                new DbContextOptions());
+            dbContext.AttachToEngine(engine, [], dependenciesMock.Object.RepositoryRegistry);
+
+            //deserialize into plain instances: the test reads the mapped members, not a repository operation
+            engine.ProxyGenerator.DisableCreationWithProxyTypes = true;
+        }
+
+        // Dispose.
+        public void Dispose()
+        {
+            (engine as IDisposable)?.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        // Data.
+        public static IEnumerable<object[]> DbMigrationOperationDeserializationTests
+        {
+            get
+            {
+                var tests = new List<DeserializationTestElement>();
+
+                // "afdb63c9-791b-41f8-8216-556e233df0de" - 0.25.0
+                {
+                    var sourceDocument =
+                        """
+                        {
+                            "_id" : ObjectId("62c0f7e5a0b1c2d3e4f50002"),
+                            "_s" : "afdb63c9-791b-41f8-8216-556e233df0de",
+                            "_t" : "DbMigrationOperation",
+                            "DbContextName" : "FakeDbContext",
+                            "CompletedDateTime" : ISODate("2026-09-01T10:05:00.000+0000"),
+                            "CurrentStatus" : "Completed",
+                            "IsDryRun" : true,
+                            "IsStopAtFirstErrorEnabled" : true,
+                            "Logs" : [
+                                {
+                                    "_s" : "d2b49514-464e-4b28-8b38-ad2d0cc69d3e",
+                                    "_t" : "DocumentMigrationLog",
+                                    "State" : "Succeded",
+                                    "CreationDateTime" : ISODate("2026-09-01T10:01:00.000+0000"),
+                                    "CollectionName" : "fakeModels",
+                                    "Errors" : [
+                                        {
+                                            "_s" : "15b8f6c8-8e94-4849-a3ce-4f0eb2cbb556",
+                                            "DocumentId" : "62c0f7e5a0b1c2d3e4f50003",
+                                            "Message" : "Unknown schema id"
+                                        }
+                                    ],
+                                    "TotErrorDocs" : NumberLong(1),
+                                    "TotMigratedDocs" : NumberLong(42)
+                                }
+                            ],
+                            "TaskId" : "1f77c0ea"
+                        }
+                        """;
+
+                    var expectedOperationMock = new Mock<DbMigrationOperation>();
+                    expectedOperationMock.Setup(op => op.Id).Returns("62c0f7e5a0b1c2d3e4f50002");
+                    expectedOperationMock.Setup(op => op.CompletedDateTime).Returns(
+                        new DateTimeOffset(2026, 09, 01, 10, 05, 00, TimeSpan.Zero));
+                    expectedOperationMock.Setup(op => op.CurrentStatus).Returns(DbMigrationOperation.Status.Completed);
+                    expectedOperationMock.Setup(op => op.DbContextName).Returns("FakeDbContext");
+                    expectedOperationMock.Setup(op => op.IsDryRun).Returns(true);
+                    expectedOperationMock.Setup(op => op.IsStopAtFirstErrorEnabled).Returns(true);
+                    expectedOperationMock.Setup(op => op.TaskId).Returns("1f77c0ea");
+                    {
+                        var documentLogMock = new Mock<DocumentMigrationLog>();
+                        documentLogMock.Setup(l => l.CollectionName).Returns("fakeModels");
+                        documentLogMock.Setup(l => l.CreationDateTime).Returns(
+                            new DateTimeOffset(2026, 09, 01, 10, 01, 00, TimeSpan.Zero));
+                        documentLogMock.Setup(l => l.Errors).Returns(
+                            [new DocumentMigrationError("62c0f7e5a0b1c2d3e4f50003", "Unknown schema id")]);
+                        documentLogMock.Setup(l => l.State).Returns(MigrationLogBase.ExecutionState.Succeded);
+                        documentLogMock.Setup(l => l.TotErrorDocs).Returns(1);
+                        documentLogMock.Setup(l => l.TotMigratedDocs).Returns(42);
+
+                        expectedOperationMock.Setup(op => op.Logs).Returns([documentLogMock.Object]);
+                    }
+
+                    tests.Add(new DeserializationTestElement(sourceDocument, expectedOperationMock.Object));
+                }
+
+                // "afdb63c9-791b-41f8-8216-556e233df0de" - MongODM 0.24, schema id on the deprecated element
+                {
+                    var sourceDocument =
+                        """
+                        {
+                            "_id" : ObjectId("62c0f7e5a0b1c2d3e4f50001"),
+                            "_m" : "afdb63c9-791b-41f8-8216-556e233df0de",
+                            "_t" : "DbMigrationOperation",
+                            "CreationDateTime" : ISODate("2024-06-01T10:00:00.000+0000"),
+                            "DbContextName" : "FakeDbContext",
+                            "CompletedDateTime" : ISODate("2024-06-01T10:05:00.000+0000"),
+                            "CurrentStatus" : "Completed",
+                            "Logs" : [
+                                {
+                                    "_m" : "d2b49514-464e-4b28-8b38-ad2d0cc69d3e",
+                                    "_t" : "DocumentMigrationLog",
+                                    "State" : "Succeded",
+                                    "CreationDateTime" : ISODate("2024-06-01T10:01:00.000+0000"),
+                                    "CollectionName" : "fakeModels",
+                                    "TotMigratedDocs" : NumberLong(42)
+                                },
+                                {
+                                    "_m" : "24d65670-a3c3-443c-977a-51112df04e2a",
+                                    "_t" : "IndexMigrationLog",
+                                    "State" : "Succeded",
+                                    "CreationDateTime" : ISODate("2024-06-01T10:02:00.000+0000"),
+                                    "Repository" : "fakeModels"
+                                }
+                            ],
+                            "TaskId" : "9d2ad0b6"
+                        }
+                        """;
+
+                    var expectedOperationMock = new Mock<DbMigrationOperation>();
+                    expectedOperationMock.Setup(op => op.Id).Returns("62c0f7e5a0b1c2d3e4f50001");
+                    expectedOperationMock.Setup(op => op.CompletedDateTime).Returns(
+                        new DateTimeOffset(2024, 06, 01, 10, 05, 00, TimeSpan.Zero));
+                    expectedOperationMock.Setup(op => op.CurrentStatus).Returns(DbMigrationOperation.Status.Completed);
+                    expectedOperationMock.Setup(op => op.DbContextName).Returns("FakeDbContext");
+                    expectedOperationMock.Setup(op => op.IsDryRun).Returns(false);
+                    expectedOperationMock.Setup(op => op.IsStopAtFirstErrorEnabled).Returns(false);
+                    expectedOperationMock.Setup(op => op.TaskId).Returns("9d2ad0b6");
+                    {
+                        //the migration errors didn't exist yet: the log reads with none of them
+                        var documentLogMock = new Mock<DocumentMigrationLog>();
+                        documentLogMock.Setup(l => l.CollectionName).Returns("fakeModels");
+                        documentLogMock.Setup(l => l.CreationDateTime).Returns(
+                            new DateTimeOffset(2024, 06, 01, 10, 01, 00, TimeSpan.Zero));
+                        documentLogMock.Setup(l => l.Errors).Returns([]);
+                        documentLogMock.Setup(l => l.State).Returns(MigrationLogBase.ExecutionState.Succeded);
+                        documentLogMock.Setup(l => l.TotErrorDocs).Returns(0);
+                        documentLogMock.Setup(l => l.TotMigratedDocs).Returns(42);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                        var indexLogMock = new Mock<IndexMigrationLog>();
+                        indexLogMock.Setup(l => l.CreationDateTime).Returns(
+                            new DateTimeOffset(2024, 06, 01, 10, 02, 00, TimeSpan.Zero));
+                        indexLogMock.Setup(l => l.Repository).Returns("fakeModels");
+                        indexLogMock.Setup(l => l.State).Returns(MigrationLogBase.ExecutionState.Succeded);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+                        expectedOperationMock.Setup(op => op.Logs).Returns(
+                            [documentLogMock.Object, indexLogMock.Object]);
+                    }
+
+                    tests.Add(new DeserializationTestElement(sourceDocument, expectedOperationMock.Object));
+                }
+
+                return tests.Select(t => new object[] { t });
+            }
+        }
+
+        // Tests.
+        [Theory, MemberData(nameof(DbMigrationOperationDeserializationTests))]
+        public void DbMigrationOperationDeserialization(DeserializationTestElement testElement)
+        {
+            ArgumentNullException.ThrowIfNull(testElement);
+
+            // Setup.
+            using var documentReader = new JsonReader(testElement.SourceDocument);
+            var modelMapSerializer = new ModelMapSerializer<DbMigrationOperation>(engine);
+            var deserializationContext = BsonDeserializationContext.CreateRoot(documentReader);
+
+            // Action.
+            using var dbExecutionContext = new DbExecutionContextHandler(engine); //run into a db execution context
+            var result = modelMapSerializer.Deserialize(deserializationContext);
+
+            // Assert.
+            Assert.Equal(testElement.ExpectedModel.Id, result.Id);
+            Assert.Equal(testElement.ExpectedModel.CompletedDateTime, result.CompletedDateTime);
+            Assert.Equal(testElement.ExpectedModel.CurrentStatus, result.CurrentStatus);
+            Assert.Equal(testElement.ExpectedModel.DbContextName, result.DbContextName);
+            Assert.Equal(testElement.ExpectedModel.IsDryRun, result.IsDryRun);
+            Assert.Equal(testElement.ExpectedModel.IsStopAtFirstErrorEnabled, result.IsStopAtFirstErrorEnabled);
+            Assert.Equal(testElement.ExpectedModel.TaskId, result.TaskId);
+
+            var expectedLogs = testElement.ExpectedModel.Logs.ToArray();
+            var resultLogs = result.Logs.ToArray();
+            Assert.Equal(expectedLogs.Length, resultLogs.Length);
+            foreach (var (expectedLog, resultLog) in expectedLogs.Zip(resultLogs))
+            {
+                Assert.Equal(expectedLog.CreationDateTime, resultLog.CreationDateTime);
+                Assert.Equal(expectedLog.State, resultLog.State);
+
+                switch (expectedLog)
+                {
+                    case DocumentMigrationLog expectedDocumentLog:
+                        var resultDocumentLog = Assert.IsType<DocumentMigrationLog>(resultLog);
+                        Assert.Equal(expectedDocumentLog.CollectionName, resultDocumentLog.CollectionName);
+                        Assert.Equal(expectedDocumentLog.TotErrorDocs, resultDocumentLog.TotErrorDocs);
+                        Assert.Equal(expectedDocumentLog.TotMigratedDocs, resultDocumentLog.TotMigratedDocs);
+                        Assert.Equal(
+                            expectedDocumentLog.Errors.Select(e => (e.DocumentId, e.Message)),
+                            resultDocumentLog.Errors.Select(e => (e.DocumentId, e.Message)));
+                        break;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                    case IndexMigrationLog expectedIndexLog:
+                        var resultIndexLog = Assert.IsType<IndexMigrationLog>(resultLog);
+                        Assert.Equal(expectedIndexLog.Repository, resultIndexLog.Repository);
+                        break;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+                    default:
+                        Assert.Fail($"Unexpected log type {expectedLog.GetType().Name}");
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/test/Scrinium.Core.UnitTests/MapRegistryTest.cs
+++ b/test/Scrinium.Core.UnitTests/MapRegistryTest.cs
@@ -93,6 +93,18 @@ namespace Etherna.Scrinium.Core
             public virtual string Id { get; set; } = null!;
             public virtual IDictionary<string, ChildModel>? LabeledChildren { get; set; }
         }
+        /* A domain constructor runs its own logic on the arguments it takes from the
+         * document, so a deserialization going through it doesn't rebuild the stored state. */
+        public class DomainConstructorModel
+        {
+            public DomainConstructorModel(string name)
+            {
+                Name = name + "-constructed";
+            }
+            protected DomainConstructorModel() { }
+
+            public string? Name { get; protected set; }
+        }
         public class EntityChildHostModel
         {
             public ChildModel? Child { get; set; }
@@ -146,6 +158,15 @@ namespace Etherna.Scrinium.Core
             public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, KeyModel value) =>
                 context.Writer.WriteString(value.Value);
         }
+        public class NoParameterlessConstructorModel
+        {
+            public NoParameterlessConstructorModel(string name)
+            {
+                Name = name + "-constructed";
+            }
+
+            public string? Name { get; protected set; }
+        }
         public class OuterLayerModel
         {
             public InnerLayerModel? Inner { get; set; }
@@ -164,6 +185,16 @@ namespace Etherna.Scrinium.Core
             {
                 public string? Name { get; set; }
             }
+        }
+        public class ReadOnlyMemberModel
+        {
+            public ReadOnlyMemberModel(string name)
+            {
+                Name = name;
+            }
+            protected ReadOnlyMemberModel() { }
+
+            public string? Name { get; }
         }
         public class SecondModel
         {
@@ -217,10 +248,55 @@ namespace Etherna.Scrinium.Core
 
         // Tests.
         [Fact]
+        public void ActiveSchemasBuildModelsWithTheirParameterlessConstructor()
+        {
+            /* SCR-287: the constructor a model declares for deserialization builds it, so the
+             * domain logic of its public constructors doesn't run on the stored values, and an
+             * element the document doesn't carry doesn't fail the read of the whole model. */
+
+            // Setup.
+            var modelMap = (IModelMap)mapRegistry.AddModelMap<DomainConstructorModel>("domainConstructorSchemaId");
+            mapRegistry.Freeze();
+
+            // Action.
+            var deserializedModel = DeserializeModel<DomainConstructorModel>(
+                modelMap.ActiveSchema.Serializer,
+                new BsonDocument("Name", "stored"));
+
+            // Assert.
+            Assert.Equal("stored", deserializedModel.Name);
+        }
+
+        [Fact]
+        public void ActiveSchemasKeepTheCreatorsOfModelsThatNeedThem()
+        {
+            /* SCR-287: a model with no parameterless constructor, or carrying a member with no
+             * setter, is reachable only through its own constructor. */
+
+            // Setup.
+            var noParameterlessConstructorMap = (IModelMap)mapRegistry.AddModelMap<NoParameterlessConstructorModel>(
+                "noParameterlessConstructorSchemaId");
+            var readOnlyMemberMap = (IModelMap)mapRegistry.AddModelMap<ReadOnlyMemberModel>("readOnlyMemberSchemaId");
+            mapRegistry.Freeze();
+
+            // Action.
+            var deserializedNoParameterlessConstructorModel = DeserializeModel<NoParameterlessConstructorModel>(
+                noParameterlessConstructorMap.ActiveSchema.Serializer,
+                new BsonDocument("Name", "stored"));
+            var deserializedReadOnlyMemberModel = DeserializeModel<ReadOnlyMemberModel>(
+                readOnlyMemberMap.ActiveSchema.Serializer,
+                new BsonDocument("Name", "stored"));
+
+            // Assert.
+            Assert.Equal("stored-constructed", deserializedNoParameterlessConstructorModel.Name);
+            Assert.Equal("stored", deserializedReadOnlyMemberModel.Name);
+        }
+
+        [Fact]
         public void ActiveSchemasCreateInstancesWithProxyGeneratorOnlyForEntityModels()
         {
             /* SCR-189: only entity model schemas replace their creators with the proxy
-             * generator; any other model keeps its natural class map creators. */
+             * generator; any other model is built by its own parameterless constructor. */
 
             // Setup.
             var proxyInstance = new FakeModel();


### PR DESCRIPTION
Fixes [SCR-287](https://etherna.atlassian.net/browse/SCR-287).

## What was wrong

The MongoDB driver maps a public constructor as a class map creator through its immutable type convention, which fires on any type whose mapped members have no public setter: exactly the shape this project prescribes for persisted models (`{ get; protected set; }`). A class map that has creators is deserialized by collecting the document values and calling `ChooseBestCreator`, which requires every argument of a creator to be present among them, so the parameterless constructor the model declares for deserialization is never used.

Until 0.24 the library neutralized this for every concrete model: `ModelMapSchema.TryUseProxyGenerator` accepted any non abstract type that wasn't already a proxy, and `UseProxyGenerator` unmapped every creator before setting the proxy one. SCR-189 narrowed that condition to concrete `IEntityModel` types while reworking the proxy system, and the creator removal went with it. Since 0.25.0 every other model is built by its own public constructor again, so its domain logic runs on the stored values at every read, and a member added to it together with its constructor parameter makes every document written before it unreadable.

That is what took down the Etherna Index dashboard: `DocumentMigrationLog` gained `Errors` and `TotErrorDocs` in 0.25 under the same schema id, so no creator matches a migration log written by MongODM 0.24, and `GetLastMigrationsAsync` fails the read of the whole operation with `BsonSerializationException: No matching creator found`. The status handler of the admin dashboard answered 500 on every poll.

## The change

`TryUseProxyGenerator` now configures the non proxy branch too: the schemas that don't use the proxy generator drop their class map creators, so their models build through the parameterless constructor and their member setters. The creator removal is shared with the proxy branch as `RemoveCreatorMaps`.

Two guards keep the creators where a model can't be built without them:

* no parameterless constructor, since the driver would otherwise build uninitialized instances and skip the field initializers;
* a creator argument reaching a member with no setter, which has no other way in.

On such a model a new constructor parameter still makes the documents written before it unreadable, and needs a new schema id. The convention is recorded in AGENTS.md, together with the ordering of the source documents in a deserialization test.

## Scope

The construction path changes for every model that is not an entity model, in every consuming application: value objects and embedded documents are no longer rebuilt by their domain constructor. Each service should run its own persistence deserialization tests against this build before its bump.

Declaring a default value on the two member maps of `DocumentMigrationLog` also clears the dashboard symptom, and was the first candidate. It was dropped once the cause turned out to be the construction path itself: it would have left every other model on the wrong one.

## Validation

* `dotnet build Scrinium.sln -c Release` green on every target framework, 0 warnings.
* `dotnet test Scrinium.sln -c Release` green, 677 tests, 673 before this change.
* New `DbMigrationOperationDeserializationTest` deserializes raw operation documents through `ModelMapSerializer`, one per version that wrote them: 0.25.0 and MongODM 0.24. On the base branch the 0.24 document fails with the production error while the 0.25.0 one passes.
* New tests in `MapRegistryTest` pin that the domain constructor no longer runs on the stored values, and that both guards keep their creators. Three mutations, three failures: dropping the call breaks two tests, dropping either guard breaks one.
* End to end on a real `mongod`: a legacy operation document inserted in `_db_ops` now reads through `GetLastMigrationsAsync`, with an empty error list and a zero error count.

## Deployment

An application already on 0.25.x whose `_db_ops` carries pre 0.25 migration logs can unblock its dashboard before this release by patching the collection:

```js
db.getCollection("_db_ops").updateMany(
  { "Logs._t": "DocumentMigrationLog" },
  { $set: { "Logs.$[log].Errors": [], "Logs.$[log].TotErrorDocs": NumberLong(0) } },
  { arrayFilters: [ { "log._t": "DocumentMigrationLog",
                      $or: [ { "log.Errors":       { $exists: false } },
                             { "log.TotErrorDocs": { $exists: false } } ] } ] })
```


[SCR-287]: https://etherna.atlassian.net/browse/SCR-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ